### PR TITLE
Adjusted the country regex for nl

### DIFF
--- a/app/Rules/HouseNumberExtension.php
+++ b/app/Rules/HouseNumberExtension.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Validation\Rule;
 class HouseNumberExtension extends LocaleBasedRule implements Rule
 {
     protected $countryRegexes = [
-        'nl' => '/^(boven|beneden|onder|hs|bis|zw|rd|[\d]{,2}|[a-z]{1})$/',
+        'nl' => '/^(boven|beneden|onder|hs|bis|zw|rd|[\d]{,2}|[0-9]|[\da-z][\da-z]?)$/',
     ];
 
     /**

--- a/tests/Unit/app/Rules/HouseNumberExtensionTest.php
+++ b/tests/Unit/app/Rules/HouseNumberExtensionTest.php
@@ -12,8 +12,11 @@ class HouseNumberExtensionTest extends TestCase
         return [
             ['nl', 'a', true],
             ['nl', 'bis', true],
-            ['nl', '11', false],
+            ['nl', '11', true],
             ['nl', 'boven', true],
+            ['nl', 'a1', true],
+            ['nl', '1c', true],
+            ['nl', 'b1ba', false],
         ];
     }
 


### PR DESCRIPTION
So the HouseNumberExtension.php can contain a numeric value like: 1a, b1, c1, 1.