### PR TITLE
Feature/copy service/final fix

### DIFF
--- a/app/Services/BuildingDataCopyService.php
+++ b/app/Services/BuildingDataCopyService.php
@@ -5,57 +5,99 @@ namespace App\Services;
 use App\Helpers\Str;
 use App\Models\Building;
 use App\Models\InputSource;
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class BuildingDataCopyService
 {
     /**
-     * Method to copy data from a building and input source to a other input source on the same building.
+     * This methods copy data by deleting the destination its input, and inserting the source its data.
+     *
+     * @param Building $building
+     * @param InputSource $from
+     * @param InputSource $to
      */
-    public static function copy(Building $building, InputSource $from, InputSource $to)
+    public static function deleteCopy(Building $building, InputSource $from, InputSource $to)
+    {
+        $tables = [
+            'building_elements',
+            'building_services',
+            'user_interests',
+            'user_action_plan_advices',
+        ];
+
+        foreach ($tables as $table) {
+
+            Log::debug("Delete copying: table {$table}");
+
+            // building to copy data from
+            $user = $building->user()->first();
+
+            // set the building or user id, depending on which column exists on the table
+            if (\Schema::hasColumn($table, 'user_id')) {
+                $buildingOrUserId = $user->id;
+                $buildingOrUserColumn = 'user_id';
+            } else {
+                $buildingOrUserId = $building->id;
+                $buildingOrUserColumn = 'building_id';
+            }
+
+            // get the input from the desired input source
+            $fromValues = \DB::table($table)
+                ->where('input_source_id', $from->id)
+                ->where($buildingOrUserColumn, $buildingOrUserId)
+                ->get()->map(fn($from, $key) => static::createInsertFromSourceArray((array)$from, $to))->toArray();
+
+            // now delete the target its input
+            DB::table($table)
+                ->where('input_source_id', $to->id)
+                ->where($buildingOrUserColumn, $buildingOrUserId)
+                ->delete();
+
+
+            // and insert the data we want to copy
+            DB::table($table)
+                ->where('input_source_id', $to->id)
+                ->where($buildingOrUserColumn, $buildingOrUserId)
+                ->insert($fromValues);
+
+        }
+    }
+
+    /**
+     * This methods copies the data using an actual update, it does not delete the destination its input.
+     *
+     * @param Building $building
+     * @param InputSource $from
+     * @param InputSource $to
+     */
+    public static function hardCopy(Building $building, InputSource $from, InputSource $to)
     {
         // the tables that have a the where_column is used to query on the resident his answers.
         $tables = [
-            'user_interests' => [
-                'where_column' => 'interested_in_id',
-                'additional_where_column' => 'interested_in_type',
-            ],
+            'building_features',
+            'building_paintwork_statuses',
+            'building_ventilations',
+            'building_pv_panels',
+            'building_heaters',
+            'building_appliances',
+            'user_energy_habits',
 
-            'building_elements' => [
-                'where_column' => 'element_id',
-                'additional_where_column' => 'element_value_id',
-            ],
-            'building_services' => [
-                'where_column' => 'service_id',
-                'additional_where_column' => 'service_value_id',
-            ],
             'building_roof_types' => [
                 'where_column' => 'roof_type_id',
             ],
             'building_insulated_glazings' => [
                 'where_column' => 'measure_application_id',
             ],
-            'building_paintwork_statuses',
             'completed_steps' => [
                 'where_column' => 'step_id',
             ],
             'questions_answers' => [
                 'where_column' => 'question_id',
             ],
-            'building_ventilations',
-            'building_features',
-            'building_pv_panels',
-            'building_heaters',
-            'building_appliances',
-
-            'user_action_plan_advices' => [
-                'where_column' => 'measure_application_id',
-                // could be added but doesnt need to be
-                'additional_where_column' => 'step_id',
-            ],
-
-            'user_energy_habits',
         ];
 
         foreach ($tables as $tableOrInt => $tableOrWhereColumns) {
@@ -65,13 +107,11 @@ class BuildingDataCopyService
             } else {
                 $table = $tableOrInt;
             }
-            Log::debug("Copy: table {$table}");
-            // building to copy data from
-            $user = $building->user()->first();
+            Log::debug("Hard copy: table {$table}");
 
-            // set the building or user id, depending on which column exists on the table
+
             if (\Schema::hasColumn($table, 'user_id')) {
-                $buildingOrUserId = $user->id;
+                $buildingOrUserId = $building->user()->first()->id;
                 $buildingOrUserColumn = 'user_id';
             } else {
                 $buildingOrUserId = $building->id;
@@ -98,74 +138,9 @@ class BuildingDataCopyService
                             ->where($buildingOrUserColumn, $buildingOrUserId)
                             ->where($whereColumn, $fromValue->$whereColumn);
 
+                        $toValue = $toValueQuery->first();
 
-                        $hasMultipleValues = false;
-                        $additionalWhereColumn = null;
-
-                        // if there are multiple values to copy from we (probably) need to query further
-                        // we also check if the additional_where_column is actually set, this way we can narrow the result down to 1 row.
-
-                        // check if there is an additional column to query on
-                        if (isset($tableOrWhereColumns['additional_where_column'])) {
-
-                            // if so, we need to check if there are multiple values
-                            // fi there is a case where the from OR to has multiple values we need to add the additional column to the update thing
-                            $additionalWhereColumn = $tableOrWhereColumns['additional_where_column'];
-                            $hasMultipleValues = $toValueQuery->count() > 1;
-
-                            if ($hasMultipleValues === false) {
-                                $hasMultipleValues = \DB::table($table)
-                                    ->where('input_source_id', $from->id)
-                                    ->where($buildingOrUserColumn, $buildingOrUserId)
-                                    ->where($whereColumn, $fromValue->$whereColumn)
-                                    ->count() > 1;
-                            }
-
-                        }
-                        if ($hasMultipleValues) {
-                            // add the where to the query
-                            $toValueQuery = $toValueQuery->where($additionalWhereColumn, $fromValue->$additionalWhereColumn);
-
-                            // get the result
-                            $toValue = $toValueQuery->first();
-
-                            // cast the results to a array
-                            $toValue = (array) $toValue;
-                            $fromValue = (array) $fromValue;
-
-                            // if it exists, we need to update it. Else we need to insert a new row.
-                            if (! empty($toValue)) {
-                                $toValueQuery->update(static::createUpdateArray($toValue, $fromValue));
-                            } else {
-                                $fromValue = static::createUpdateArray((array) $toValue, (array) $fromValue);
-                                // change the input source id to the 'to' id
-                                $fromValue['input_source_id'] = $to->id;
-                                $fromValue[$buildingOrUserColumn] = $buildingOrUserId;
-                                // and insert a new row!
-                                \DB::table($table)->insert($fromValue);
-                            }
-                        } else {
-                            $toValue = $toValueQuery->first();
-
-                            // cast the results to a array
-                            $toValue = (array) $toValue;
-                            $fromValue = (array) $fromValue;
-
-                            // YAY! data has been copied so update or create the target input source his records.
-                            if ($toValueQuery->first() instanceof \stdClass) {
-                                // check if its empty ornot.
-                                if (! empty($updateData = static::createUpdateArray((array) $toValue, (array) $fromValue))) {
-                                    $toValueQuery->update($updateData);
-                                }
-                            } else {
-                                $fromValue = static::createUpdateArray((array) $toValue, (array) $fromValue);
-                                // change the input source id to the 'to' id
-                                $fromValue['input_source_id'] = $to->id;
-                                $fromValue[$buildingOrUserColumn] = $buildingOrUserId;
-                                // and insert a new row!
-                                \DB::table($table)->insert($fromValue);
-                            }
-                        }
+                        static::updateOrInsert($to, $fromValue, $toValue, $toValueQuery, $buildingOrUserColumn, $buildingOrUserId);
                     }
                 }
             } else {
@@ -178,25 +153,75 @@ class BuildingDataCopyService
                 $fromValue = $fromValues->first();
                 $toValue = $toValueQuery->first();
 
-                if ($toValue instanceof \stdClass) {
-                    if (! empty($updateData = static::createUpdateArray((array) $toValue, (array) $fromValue))) {
-                        $toValueQuery->update($updateData);
-                    }
-                } else {
-                    $fromValue = (array) $fromValue;
-                    // unset the stuff we dont want to insert
-                    $fromValue = static::createUpdateArray((array) $toValue, (array) $fromValue);
-                    // change the input source id to the 'to' id
-                    $fromValue['input_source_id'] = $to->id;
-                    $fromValue[$buildingOrUserColumn] = $buildingOrUserId;
-
-                    // and insert a new row!
-                    \DB::table($table)->insert($fromValue);
-                }
+                static::updateOrInsert($to, $fromValue, $toValue, $toValueQuery, $buildingOrUserColumn, $buildingOrUserId);
             }
         }
+    }
 
-        Artisan::call('fix:duplicates');
+    public static function createInsertFromSourceArray(array $fromData, InputSource $to): array
+    {
+        unset($fromData['id']);
+
+        // if its empty we set the dates to now.
+        $fromData['created_at'] = $fromData['created_at'] ?? Carbon::now()->toDateTimeString();
+        $fromData['updated_at'] = $fromData['updated_at'] ?? Carbon::now()->toDateTimeString();
+        $fromData['input_source_id'] = $to->id;
+
+        if (array_key_exists('extra', $fromData)) {
+
+            $extra = json_decode($fromData['extra'], true);
+            if (!is_null($extra)) {
+                $fromData['extra'] = static::filterExtraColumn($extra);
+            }
+            // some extra column contain "null", we dont want that
+            if ($fromData['extra'] === "null") {
+                $fromData['extra'] = [];
+            }
+            $fromData['extra'] = json_encode($fromData['extra']);
+        }
+
+        return $fromData;
+    }
+
+    /**
+     * Method to updateOrInsert the source to the destination
+     *
+     * @param InputSource $to
+     * @param \stdClass|null $fromValue
+     * @param \stdClass|null $toValue
+     * @param $toValueQuery
+     * @param string $buildingOrUserColumn
+     * @param string $buildingOrUserId
+     */
+    public static function updateOrInsert(InputSource $to, $fromValue, $toValue, $toValueQuery, string $buildingOrUserColumn, string $buildingOrUserId)
+    {
+        if ($toValue instanceof \stdClass) {
+            // if the source has no valid data we dont do a update
+            if (!empty($updateData = static::createUpdateArray((array)$toValue, (array)$fromValue))) {
+                $toValueQuery->update($updateData);
+            }
+        } else {
+            // unset the stuff we dont want to insert
+            $fromValue = static::createUpdateArray((array)$toValue, (array)$fromValue);
+            // change the input source id to the 'to' id
+            $fromValue['input_source_id'] = $to->id;
+            $fromValue[$buildingOrUserColumn] = $buildingOrUserId;
+
+            // and insert a new row!
+            \DB::table($toValueQuery->from)->insert($fromValue);
+        }
+    }
+
+    /**
+     * Method to copy data from a building and input source to a other input source on the same building.
+     */
+    public static function copy(Building $building, InputSource $from, InputSource $to)
+    {
+        static::hardCopy($building, $from, $to);
+        static::deleteCopy($building, $from, $to);
+
+        dd('bubbke');
+//        Artisan::call('fix:duplicates');
     }
 
     /**
@@ -245,7 +270,7 @@ class BuildingDataCopyService
     {
         return array_filter($extraColumnData, function ($extraValue, $extraKey) {
             // if the string is not considered empty, and its need an update. Then we add it
-            return ! Str::isConsideredEmptyAnswer($extraValue) && static::keyNeedsUpdate($extraKey);
+            return !Str::isConsideredEmptyAnswer($extraValue) && static::keyNeedsUpdate($extraKey);
         }, ARRAY_FILTER_USE_BOTH);
     }
 
@@ -260,7 +285,7 @@ class BuildingDataCopyService
         $updateArray = [];
 
         // if the desired input source has a extra key and its not empty, then we start to compare and merge the extra column.
-        if (array_key_exists('extra', $inputSourceToCopy) && ! empty($inputSourceToCopy['extra']) && is_array($inputSourceToCopy['extra'])) {
+        if (array_key_exists('extra', $inputSourceToCopy) && !empty($inputSourceToCopy['extra']) && is_array($inputSourceToCopy['extra'])) {
             if (empty($inputSourceToUpdate['extra'])) {
                 $inputSourceToCopyExtra = json_decode($inputSourceToCopy['extra'], true);
 
@@ -293,11 +318,12 @@ class BuildingDataCopyService
         // now update the "normal" values
         foreach ($inputSourceToCopy as $desiredInputSourceKey => $desiredInputSourceAnswer) {
             // if the answer from the desired input source is not empty and the key needs a update, then we update the resident his answer.
-            if ((! empty($desiredInputSourceAnswer) || static::isRadioInput($desiredInputSourceKey)) && static::keyNeedsUpdate($desiredInputSourceKey)) {
+            if ((!empty($desiredInputSourceAnswer) || static::isRadioInput($desiredInputSourceKey)) && static::keyNeedsUpdate($desiredInputSourceKey)) {
                 $updateArray[$desiredInputSourceKey] = $desiredInputSourceAnswer;
             }
         }
 
+        $updateArray['updated_at'] = Carbon::now()->toDateTimeString();
         return $updateArray;
     }
 }

--- a/app/Services/BuildingDataCopyService.php
+++ b/app/Services/BuildingDataCopyService.php
@@ -109,13 +109,6 @@ class BuildingDataCopyService
         }
     }
 
-    private static function toRawSql($query)
-    {
-        return array_reduce($query->getBindings(), function ($sql, $binding) {
-            return preg_replace('/\?/', is_numeric($binding) ? $binding : "'" . $binding . "'", $sql, 1);
-        }, $query->toSql());
-    }
-
     /**
      * This methods copies the data using an actual update, it does not delete the destination its input.
      *

--- a/app/Services/BuildingDataCopyService.php
+++ b/app/Services/BuildingDataCopyService.php
@@ -217,11 +217,13 @@ class BuildingDataCopyService
      */
     public static function copy(Building $building, InputSource $from, InputSource $to)
     {
+        $userId = \Auth::id();
+
+        Log::debug("BUILDING_ID: {$building->id}");
+        Log::debug("AUTH_USER_ID: {$userId}");
+
         static::hardCopy($building, $from, $to);
         static::deleteCopy($building, $from, $to);
-
-        dd('bubbke');
-//        Artisan::call('fix:duplicates');
     }
 
     /**

--- a/database/migrations/2021_02_18_111851_int_to_bigint_for_id_column_on_various_tables.php
+++ b/database/migrations/2021_02_18_111851_int_to_bigint_for_id_column_on_various_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class IntToBigintForIdColumnOnVariousTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tables = [
+            'building_elements',
+            'building_services',
+            'user_interests',
+            'user_action_plan_advices',
+        ];
+        Schema::table('appliance_building_services', function ($table) {
+            $table->dropForeign(['building_service_id']);
+        });
+        foreach ($tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) {
+                $table->bigIncrements('id')->change();
+            });
+        }
+
+        Schema::table('appliance_building_services', function (Blueprint $table) {
+            $table->unsignedBigInteger('building_service_id')->change();
+            $table->foreign('building_service_id')->on('building_services')->references('id')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tables = [
+            'building_elements',
+            'building_services',
+            'user_interests',
+            'user_action_plan_advices',
+        ];
+        Schema::table('appliance_building_services', function ($table) {
+            $table->dropForeign(['building_service_id']);
+        });
+        foreach ($tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) {
+                $table->unsignedInteger('id')->change();
+            });
+        }
+
+        Schema::table('appliance_building_services', function (Blueprint $table) {
+            $table->unsignedInteger('building_service_id')->change();
+            $table->foreign('building_service_id')->on('building_services')->references('id')->onDelete('cascade');
+        });
+    }
+}


### PR DESCRIPTION
Partial rewrite of the BuildingDataCopyService::copy( ) method.

Removed duplicate code, added more debug logs. For some tables its better to do a delete copy, this is more foolproof.