### PR TITLE
Fixes the recalculate notification for good.

### DIFF
--- a/app/Console/Commands/Tool/RecalculateForUser.php
+++ b/app/Console/Commands/Tool/RecalculateForUser.php
@@ -7,6 +7,7 @@ use App\Jobs\RecalculateStepForUser;
 use App\Models\CompletedStep;
 use App\Models\Cooperation;
 use App\Models\InputSource;
+use App\Models\Notification;
 use App\Models\Step;
 use App\Models\User;
 use Illuminate\Console\Command;
@@ -71,35 +72,39 @@ class RecalculateForUser extends Command
             $inputSourcesToRecalculate = $this->option('input-source');
         }
 
-        $inputSources = InputSource::whereIn('short', $inputSourcesToRecalculate)
-            ->pluck('id')
-            ->toArray();
+        $inputSources = InputSource::whereIn('short', $inputSourcesToRecalculate)->get();
 
         /** @var User $user */
         foreach ($users as $user) {
             $bar->advance(1);
 
-            // get the completed steps for a user.
-            $completedSteps = $user->building
-                ->completedSteps()
-                ->whereHas('step', function (Builder $query) {
-                    $query->whereNotIn('steps.short', ['general-data', 'heat-pump'])
-                        ->whereNull('parent_id');
-                })->with(['inputSource', 'step'])
-                ->whereIn('input_source_id', $inputSources)
-                ->forMe($user)
-                ->get();
+            foreach ($inputSources as $inputSource) {
 
-            $stepsToRecalculateChain = [];
+                $completedSteps = $user->building
+                    ->completedSteps()
+                    ->forInputSource($inputSource)
+                    ->whereHas('step', function ($query) {
+                        $query
+                            ->whereNotIn('steps.short', ['general-data', 'heat-pump'])
+                            ->whereNull('parent_id');
+                    })
+                    ->get();
 
-            /** @var CompletedStep $completedStep */
-            foreach ($completedSteps as $completedStep) {
-                // user is interested, so recreate the advices for each step
-                $stepsToRecalculateChain[] = new RecalculateStepForUser($user, $completedStep->inputSource, $completedStep->step);
-            }
+                if ($completedSteps->isNotEmpty()) {
+                    Notification::setActive($user->building, $inputSource, true);
+                }
 
-            if (! empty($stepsToRecalculateChain)) {
-                ProcessRecalculate::withChain($stepsToRecalculateChain)->dispatch();
+                $stepsToRecalculateChain = [];
+
+                /** @var CompletedStep $completedStep */
+                foreach ($completedSteps as $completedStep) {
+                    // user is interested, so recreate the advices for each step
+                    $stepsToRecalculateChain[] = new RecalculateStepForUser($user, $inputSource, $completedStep->step);
+                }
+
+                if (! empty($stepsToRecalculateChain)) {
+                    ProcessRecalculate::withChain($stepsToRecalculateChain)->dispatch();
+                }
             }
         }
         $bar->finish();

--- a/app/Listeners/RecalculateToolForUserListener.php
+++ b/app/Listeners/RecalculateToolForUserListener.php
@@ -4,6 +4,8 @@ namespace App\Listeners;
 
 use App\Helpers\HoomdossierSession;
 use App\Models\Notification;
+use App\Models\Step;
+use Illuminate\Support\Facades\Artisan;
 
 class RecalculateToolForUserListener
 {
@@ -37,13 +39,17 @@ class RecalculateToolForUserListener
         ];
 
         if (in_array($event->step->short, $stepsWhichNeedRecalculation)) {
+            $inputSource = HoomdossierSession::getInputSource(true);
+
             // currently this listener will only be triggered on a event thats dispatched while NOT running in the cli
             // so we can safely access the input source from the session
-            Notification::setActive($event->building, HoomdossierSession::getInputSource(true), true);
+
+            if ($event->building->hasCompleted(Step::findByShort('general-data')))
+            Notification::setActive($event->building, $inputSource, true);
 
             // recalculate the tool for the given user
             $userId = $event->building->user->id;
-            \Artisan::call('tool:recalculate', ['--user' => [$userId]]);
+            Artisan::call('tool:recalculate', ['--user' => [$userId], '--input-source' => [$inputSource->short]]);
         }
     }
 }


### PR DESCRIPTION
The completed steps query was used for multiple input sources. This is now narrowed down to 1 input source only, so;

 - Get the user
 - Get all the completed steps from the user, on a specific input source
 - If there are completed steps turn on the notification
 - Prep all the ProcessRecalculate jobs
 - When the job is done, turn of the notification