### PR TITLE
Register pico fix.

### DIFF
--- a/app/Http/Controllers/Api/GeoController.php
+++ b/app/Http/Controllers/Api/GeoController.php
@@ -16,6 +16,10 @@ class GeoController extends Controller
 
         $address = PicoHelper::getAddressData($postalCode, $number, $houseNumberExtension);
 
+        if (empty($address)) {
+            $address = $request->all();
+        }
+
         return response()->json($address);
     }
 }


### PR DESCRIPTION
If the pico address returns an empty array we just return the request data, this way the user can complete the registration process