### PR TITLE
Assign the correct status upon registering

### DIFF
--- a/app/Listeners/GiveCoachesBuildingPermission.php
+++ b/app/Listeners/GiveCoachesBuildingPermission.php
@@ -71,9 +71,6 @@ class GiveCoachesBuildingPermission
                 'building_id' => $building->id,
             ]);
 
-            // what should we set the building status to ?
-            $building->setStatus('pending');
-
             // give the user a unread message.
             PrivateMessageView::create([
                 'input_source_id' => InputSource::findByShort(InputSource::RESIDENT_SHORT)->id,


### PR DESCRIPTION
Previously the user would get the status pending after he gave permision to his building. but because of recent changes, giving permissions is mandatory.

So now we will just assign the status active