### PR TITLE
Feature/develop upgrade/step stuff

### DIFF
--- a/app/Console/Commands/Tool/RecalculateForUser.php
+++ b/app/Console/Commands/Tool/RecalculateForUser.php
@@ -88,7 +88,8 @@ class RecalculateForUser extends Command
                     ->forInputSource($inputSource)
                     ->whereHas('step', function ($query) {
                         $query
-                            ->whereNotIn('steps.short', ['general-data', 'heat-pump'])
+                            ->whereNotIn('steps.short', ['general-data', 'heat-pump', 'building-data',
+                                'usage-quick-scan', 'living-requirements', 'residential-status'])
                             ->whereNull('parent_id');
                     })
                     ->get();

--- a/app/Http/Controllers/Cooperation/Tool/WallInsulationController.php
+++ b/app/Http/Controllers/Cooperation/Tool/WallInsulationController.php
@@ -10,7 +10,6 @@ use App\Helpers\HoomdossierSession;
 use App\Helpers\StepHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Cooperation\Tool\WallInsulationRequest;
-use App\Jobs\RecalculateStepForUser;
 use App\Models\Building;
 use App\Models\BuildingElement;
 use App\Models\BuildingFeature;

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
@@ -259,7 +259,7 @@ class Form extends Component
                 break;
 
             default:
-            $this->rules["filledInAnswers.{$toolQuestion->id}"] = $toolQuestion->validation;
+                $this->rules["filledInAnswers.{$toolQuestion->id}"] = $toolQuestion->validation;
                 break;
         }
     }

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
@@ -186,18 +186,12 @@ class Form extends Component
         // TODO: @bodhi what is the use of this line
         $this->toolQuestions = $this->subStep->toolQuestions;
 
-        // now mark the sub step as complete
+        // Now mark the sub step as complete
         CompletedSubStep::firstOrCreate([
             'sub_step_id' => $this->subStep->id,
             'building_id' => $this->building->id,
             'input_source_id' => $this->currentInputSource->id
         ]);
-
-        $lastSubStepForStep = $this->step->subSteps()->orderByDesc('order')->first();
-        // last substep is done, now we can complete the main step
-        if ($this->subStep->id === $lastSubStepForStep->id) {
-            StepHelper::complete($this->step, $this->building, $this->currentInputSource);
-        }
 
         return redirect()->to($nextUrl);
     }

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Livewire\Cooperation\Frontend\Tool\QuickScan;
 
+use App\Events\StepDataHasBeenChanged;
 use App\Helpers\Conditions\ConditionEvaluator;
+use App\Helpers\Hoomdossier;
 use App\Helpers\HoomdossierSession;
 use App\Helpers\StepHelper;
 use App\Helpers\ToolQuestionHelper;
@@ -44,6 +46,7 @@ class Form extends Component
 
     public $toolQuestions;
 
+    public bool $dirty;
     public $filledInAnswers = [];
     public $filledInAnswersForAllInputSources = [];
 
@@ -77,6 +80,7 @@ class Form extends Component
 
         $this->setToolQuestions();
 
+        $this->dirty = true;
     }
 
     private function setToolQuestions()
@@ -163,18 +167,23 @@ class Form extends Component
             $validator->validate();
         }
 
-
-        foreach ($this->filledInAnswers as $toolQuestionId => $givenAnswer) {
-            /** @var ToolQuestion $toolQuestion */
-            $toolQuestion = ToolQuestion::where('id', $toolQuestionId)->with('toolQuestionType')->first();
-            if (is_null($toolQuestion->save_in)) {
-                $this->saveToolQuestionCustomValues($toolQuestion, $givenAnswer);
-            } else {
-                // this *can't* handle a checkbox / multiselect answer.
-                $this->saveToolQuestionValuables($toolQuestion, $givenAnswer);
+        // Answers have been updated, we save them and dispatch a recalculate
+        if ($this->dirty) {
+            foreach ($this->filledInAnswers as $toolQuestionId => $givenAnswer) {
+                /** @var ToolQuestion $toolQuestion */
+                $toolQuestion = ToolQuestion::where('id', $toolQuestionId)->with('toolQuestionType')->first();
+                if (is_null($toolQuestion->save_in)) {
+                    $this->saveToolQuestionCustomValues($toolQuestion, $givenAnswer);
+                } else {
+                    // this *can't* handle a checkbox / multiselect answer.
+                    $this->saveToolQuestionValuables($toolQuestion, $givenAnswer);
+                }
             }
+
+            StepDataHasBeenChanged::dispatch($this->step, $this->building, Hoomdossier::user());
         }
 
+        // TODO: @bodhi what is the use of this line
         $this->toolQuestions = $this->subStep->toolQuestions;
 
         // now mark the sub step as complete
@@ -237,6 +246,8 @@ class Form extends Component
 
         // User's previous values could be defined, which means conditional questions should be hidden
         $this->setToolQuestions();
+
+        $this->dirty = false;
     }
 
     private function setValidationForToolQuestion(ToolQuestion $toolQuestion)

--- a/app/Jobs/RecalculateStepForUser.php
+++ b/app/Jobs/RecalculateStepForUser.php
@@ -42,9 +42,13 @@ class RecalculateStepForUser implements ShouldQueue
     {
         Log::debug('Recalculating step: '.$this->step->name);
         $stepClass = 'App\\Helpers\\Cooperation\Tool\\'.Str::singular(Str::studly($this->step->short)).'Helper';
-        /** @var ToolHelper $stepHelperClass */
-        $stepHelperClass = new $stepClass($this->user, $this->inputSource);
-        $stepHelperClass->createValues()->createAdvices();
+
+        // Some steps don't have tool helpers. Let's check if it exists first
+        if (class_exists($stepClass)) {
+            /** @var ToolHelper $stepHelperClass */
+            $stepHelperClass = new $stepClass($this->user, $this->inputSource);
+            $stepHelperClass->createValues()->createAdvices();
+        }
     }
 
 

--- a/app/Listeners/RecalculateToolForUserListener.php
+++ b/app/Listeners/RecalculateToolForUserListener.php
@@ -45,7 +45,7 @@ class RecalculateToolForUserListener
             $inputSource = HoomdossierSession::getInputSource(true);
 
             // Theres nothing to recalculate if the user did not complete the main step.
-            if ($event->building->hasCompleted(Step::findByShort('general-data'))) {
+            if ($event->building->hasCompletedQuickScan()) {
                 $userId = $event->building->user->id;
                 Artisan::call(RecalculateForUser::class, ['--user' => [$userId], '--input-source' => [$inputSource->short]]);
 

--- a/app/Listeners/RecalculateToolForUserListener.php
+++ b/app/Listeners/RecalculateToolForUserListener.php
@@ -2,6 +2,7 @@
 
 namespace App\Listeners;
 
+use App\Console\Commands\Tool\RecalculateForUser;
 use App\Helpers\HoomdossierSession;
 use App\Models\Notification;
 use App\Models\Step;
@@ -46,7 +47,8 @@ class RecalculateToolForUserListener
             // Theres nothing to recalculate if the user did not complete the main step.
             if ($event->building->hasCompleted(Step::findByShort('general-data'))) {
                 $userId = $event->building->user->id;
-                Artisan::call('tool:recalculate', ['--user' => [$userId], '--input-source' => [$inputSource->short]]);
+                Artisan::call(RecalculateForUser::class, ['--user' => [$userId], '--input-source' => [$inputSource->short]]);
+
             }
         }
     }

--- a/app/Listeners/RecalculateToolForUserListener.php
+++ b/app/Listeners/RecalculateToolForUserListener.php
@@ -29,18 +29,26 @@ class RecalculateToolForUserListener
     public function handle($event)
     {
         $stepsWhichNeedRecalculation = [
+            // Algemene gegevens
             'building-characteristics',
             'current-state',
             'usage',
             'interest',
 
+            // Quick scan (Replaces algemene gegevens so must trigger a recalculate!)
+            'building-data',
+            'usage-quick-scan',
+            'living-requirements',
+            'residential-status',
+
+            // Expert tool relevant steps
             'high-efficiency-boiler',
             'solar-panels',
             'heater',
         ];
 
         if (in_array($event->step->short, $stepsWhichNeedRecalculation)) {
-            // currently this listener will only be triggered on a event thats dispatched while NOT running in the cli
+            // Currently this listener will only be triggered on a event that's dispatched while NOT running in the cli
             // so we can safely access the input source from the session
             $inputSource = HoomdossierSession::getInputSource(true);
 
@@ -48,7 +56,6 @@ class RecalculateToolForUserListener
             if ($event->building->hasCompletedQuickScan()) {
                 $userId = $event->building->user->id;
                 Artisan::call(RecalculateForUser::class, ['--user' => [$userId], '--input-source' => [$inputSource->short]]);
-
             }
         }
     }

--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\StepHelper;
 use App\Helpers\ToolQuestionHelper;
 use App\Scopes\GetValueScope;
 use App\ToolQuestionAnswer;
@@ -318,6 +319,23 @@ class Building extends Model
 
         return $this->completedSteps()
                     ->where('step_id', $step->id)->count() > 0;
+    }
+
+    /**
+     * Check if all quick scan steps have been completed
+     *
+     * @return bool
+     */
+    public function hasCompletedQuickScan(): bool
+    {
+        $quickScanSteps = Step::whereIn('short', StepHelper::QUICK_SCAN_STEP_SHORTS)->get();
+        foreach ($quickScanSteps as $quickScanStep) {
+            if (! $this->hasCompleted($quickScanStep)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/app/Models/CompletedSubStep.php
+++ b/app/Models/CompletedSubStep.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\StepHelper;
 use App\Traits\GetMyValuesTrait;
 use App\Traits\GetValueTrait;
 use Illuminate\Database\Eloquent\Model;
@@ -10,13 +11,50 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class CompletedSubStep extends Model
 {
 
-    use GetMyValuesTrait;
-    use GetValueTrait;
+    use GetMyValuesTrait,
+        GetValueTrait;
 
     protected $fillable = ['sub_step_id', 'building_id', 'input_source_id'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saved(function ($completedSubStep) {
+            // Check if this sub step finished the step
+            $subStep = $completedSubStep->subStep;
+
+            if ($subStep instanceof SubStep) {
+                $step = $subStep->step;
+                $inputSource = $completedSubStep->inputSource;
+                $building = $completedSubStep->building;
+
+                if ($step instanceof Step && $inputSource instanceof InputSource && $building instanceof Building) {
+                    $allCompletedSubStepIds = CompletedSubStep::forInputSource($inputSource)
+                        ->forBuilding($building)
+                        ->whereHas('subStep', function ($query) use ($step) {
+                            $query->where('step_id', $step->id);
+                        })
+                        ->pluck('sub_step_id')->toArray();
+
+                    $allSubStepIds = $step->subSteps()->pluck('id')->toArray();
+
+                    if (empty (array_diff($allSubStepIds, $allCompletedSubStepIds))) {
+                        // The sub step that has been completed finished up the set, so we complete the main step
+                        StepHelper::complete($step, $building, $inputSource);
+                    }
+                }
+            }
+        });
+    }
 
     public function subStep(): BelongsTo
     {
         return $this->belongsTo(SubStep::class);
+    }
+
+    public function building(): BelongsTo
+    {
+        return $this->belongsTo(Building::class);
     }
 }

--- a/app/Traits/GetMyValuesTrait.php
+++ b/app/Traits/GetMyValuesTrait.php
@@ -61,7 +61,7 @@ trait GetMyValuesTrait
 
         $crucialRelationCombinationIds = [
             'user_id', 'building_id', 'tool_question_id', 'element_id', 'service_id',
-            'hash',
+            'hash', 'sub_step_id',
         ];
         if ($this instanceof UserActionPlanAdvice){
             $advisable = $this->userActionPlanAdvisable;


### PR DESCRIPTION
This PR adds the following:
- Fixes the recalculate exception for non-existing Tool Helpers
- Ensures the recalculate triggers from quick scan
- Ensure the recalculate triggers based on the quick scan being complete (and not general data)
- Removes the quick scan step shorts from the list of completed steps to process
- Only save tool questions if something was changed
- Set step as complete if all sub steps have been completed, instead of fixing it based on the last sub step