### PR TITLE
Example building tool question additions

### DIFF
--- a/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
+++ b/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Helpers\Conditions\Evaluators;
+
+use App\Models\Building;
+use App\Models\ExampleBuilding;
+use App\Models\InputSource;
+use App\Models\ToolQuestion;
+
+class SpecificExampleBuilding implements ShouldEvaluate
+{
+    public static function evaluate(Building $building, InputSource $inputSource): bool
+    {
+        $buildingTypeId = $building->getAnswer(
+            $inputSource,
+            ToolQuestion::findByShort('building-type')
+        );
+
+        $specificExampleBuildingExists = ExampleBuilding::where('cooperation_id', $building->user->cooperation_id)
+            ->where('building_type_id', '=', $buildingTypeId)
+            ->exists();
+
+        $genericExampleBuildingCountForBuildingType = ExampleBuilding::where('building_type_id', '=', $buildingTypeId)
+            ->whereNull('cooperation_id')
+            ->count();
+
+        // when there is only 1 generic example building and no specific example buildings we want to skip the step
+        // because there are just no choices to be made here.
+        return $specificExampleBuildingExists || $genericExampleBuildingCountForBuildingType > 1;
+    }
+}

--- a/app/Helpers/QuestionValues/SpecificExampleBuilding.php
+++ b/app/Helpers/QuestionValues/SpecificExampleBuilding.php
@@ -11,13 +11,33 @@ class SpecificExampleBuilding implements ShouldReturnQuestionValues
 {
     public static function getQuestionValues(Collection $questionValues, Building $building, InputSource $inputSource): Collection
     {
+        // get the current example building for the user
+        $buildingFeature = $building->buildingFeatures()->forInputSource($inputSource)->first();
+
         $conditionalQuestion = ToolQuestion::findByShort('building-type');
         $cooperationId = $building->user->cooperation_id;
 
         $buildingTypeId = $building->getAnswer($inputSource, $conditionalQuestion);
 
+
         $specificExampleBuildings = $questionValues->where('building_type_id', $buildingTypeId)->where('cooperation_id', $cooperationId);
-        $genericExampleBuildings = $questionValues->where('building_type_id', $buildingTypeId)->whereNull('cooperation_id');
+        $genericExampleBuildings = $questionValues
+            ->where('building_type_id', $buildingTypeId)
+            ->whereNull('cooperation_id')
+            ->where('value', '!=', $buildingFeature->example_building_id);
+
+        // now we will change the current selected GENERIC example building name to "Geen van deze"
+        $currentExampleBuilding = $questionValues
+            ->where('building_type_id', $buildingTypeId)
+            ->whereNull('cooperation_id')
+            ->where('value', $buildingFeature->example_building_id)
+            ->first();
+
+        // its an array when its found.
+        if (is_array($currentExampleBuilding)) {
+            $currentExampleBuilding['name'] = "Geen van de overige opties.";
+            $genericExampleBuildings->push($currentExampleBuilding);
+        }
 
         return $genericExampleBuildings->merge($specificExampleBuildings);
     }

--- a/app/Helpers/QuestionValues/SpecificExampleBuilding.php
+++ b/app/Helpers/QuestionValues/SpecificExampleBuilding.php
@@ -16,15 +16,9 @@ class SpecificExampleBuilding implements ShouldReturnQuestionValues
 
         $buildingTypeId = $building->getAnswer($inputSource, $conditionalQuestion);
 
-        return $questionValues
-            ->filter(function (array $questionValue) use ($buildingTypeId, $cooperationId) {
+        $specificExampleBuildings = $questionValues->where('building_type_id', $buildingTypeId)->where('cooperation_id', $cooperationId);
+        $genericExampleBuildings = $questionValues->where('building_type_id', $buildingTypeId)->whereNull('cooperation_id');
 
-                $matchesBuildingTypeAndIsForUserItsCooperation = ($questionValue['building_type_id'] == $buildingTypeId && $questionValue['cooperation_id'] == $cooperationId);
-                $matchedBuildingTypeButIsGeneric = ($questionValue['building_type_id'] == $buildingTypeId && is_null($questionValue['cooperation_id']));
-
-
-                return $matchesBuildingTypeAndIsForUserItsCooperation || $matchedBuildingTypeButIsGeneric;
-            });
-
+        return $genericExampleBuildings->merge($specificExampleBuildings);
     }
 }

--- a/database/seeds/ToolQuestionsTableSeeder.php
+++ b/database/seeds/ToolQuestionsTableSeeder.php
@@ -254,6 +254,14 @@ class ToolQuestionsTableSeeder extends Seeder
                     ]
                 ],
                 'Specifieke voorbeeld woning' => [
+                    'conditions' => [
+                        [
+                            [
+                                'column' => 'fn',
+                                'value' => 'SpecificExampleBuilding',
+                            ],
+                        ],
+                    ],
                     'order' => 4,
                     'sub_step_template_id' => $templateDefault->id,
                     'questions' => [


### PR DESCRIPTION
This pr adds the following
 - Skips the example building question when there are no other options to select (eg the user has selected a generic example building and there are no other specific / generic ones available)
 - Shows the current generic example building as "None of the above"