### PR TITLE
No coach name when not available on front page of pdf.

### DIFF
--- a/resources/views/cooperation/pdf/user-report/parts/front-page.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/front-page.blade.php
@@ -8,7 +8,9 @@
         <h2>{{$userCooperation->name}}</h2>
         <h2>{{date('d-m-Y')}}</h2>
         @php($coachNames = implode(', ', $connectedCoachNames))
-        <h2>{{trans_choice('pdf/user-report.front-page.intro.connected-coaches', count($connectedCoachNames)).' '.$coachNames}}</h2>
+        @if(!empty($coachNames))
+            <h2>{{trans_choice('pdf/user-report.front-page.intro.connected-coaches', count($connectedCoachNames)).' '.$coachNames}}</h2>
+        @endif
     </div>
 
 


### PR DESCRIPTION
Dont show the connected coach text on the front page of the pdf when no connected coaches are available.