### PR TITLE
Local PDF docker styling fix.

### DIFF
--- a/resources/views/cooperation/pdf/user-report/index.blade.php
+++ b/resources/views/cooperation/pdf/user-report/index.blade.php
@@ -5,7 +5,16 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
-    <link rel="stylesheet" type="text/css" href="{{ asset('css/pdf.css') }}">
+    @if(app()->environment() === 'local')
+        @php
+          $href = $_SERVER['DOCUMENT_ROOT'] . '/css/pdf.css';
+        @endphp
+    @else
+        @php
+            $href = asset('css/pdf.css');
+        @endphp
+    @endif
+    <link rel="stylesheet" type="text/css" href="{{ $href }}">
     <title>Document</title>
 </head>
 


### PR DESCRIPTION
Locally we can use the document root, this is because the pdf can find that on the docker environment. We use asset on live because thats elite.