### PR TITLE
oldAdvice bugfix

### DIFF
--- a/app/Services/UserActionPlanAdviceService.php
+++ b/app/Services/UserActionPlanAdviceService.php
@@ -57,6 +57,7 @@ class UserActionPlanAdviceService
         $oldAdvices = UserActionPlanAdvice::forUser($user)
             ->forInputSource($masterInputSource)
             ->forStep($step)
+            ->withInvisible()
             ->get();
 
         // now delete the old advices, the one for the given input source and the master source.


### PR DESCRIPTION
Added the withInvisible scope to the oldAdvices, crucial to return al the old advices so we dont lose the "state" of the cards.

Minor mistake, big impact.