### PR TITLE
QuickScan recalculate fix

### DIFF
--- a/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
@@ -258,8 +258,8 @@ class Form extends Component
             }
         }
 
-        // the INITIAL calculation will be handled by the CompletedSubStepObserver
 
+        // the INITIAL calculation will be handled by the CompletedSubStepObserver
         if ($shouldDoFullRecalculate) {
             // We should do a full recalculate because some base value that has impact on every calculation is changed.
             Log::debug("Dispatching full recalculate..");
@@ -271,7 +271,7 @@ class Form extends Component
                 '--with-old-advices' => true,
             ]);
 
-        } else if ($masterHasCompletedQuickScan) {
+        } else if ($masterHasCompletedQuickScan && !empty($stepShortsToRecalculate)) {
             // the user already has completed the quick scan, so we will only recalculate specific parts of the advices.
             $stepShortsToRecalculate = array_unique($stepShortsToRecalculate);
             // since we are just re-calculating specific parts of the tool we do it without the old advices
@@ -285,9 +285,6 @@ class Form extends Component
                 '--with-old-advices' => false,
             ]);
         }
-
-        // TODO: @bodhi what is the use of this line
-        $this->toolQuestions = $this->subStep->toolQuestions;
 
         // Now mark the sub step as complete
         CompletedSubStep::firstOrCreate([

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/QuickScan/Form.php
@@ -271,6 +271,7 @@ class Form extends Component
                 '--with-old-advices' => true,
             ]);
 
+            // only when there are steps to recalculate, otherwise the command would just do a FULL recalculate.
         } else if ($masterHasCompletedQuickScan && !empty($stepShortsToRecalculate)) {
             // the user already has completed the quick scan, so we will only recalculate specific parts of the advices.
             $stepShortsToRecalculate = array_unique($stepShortsToRecalculate);
@@ -281,7 +282,6 @@ class Form extends Component
                 '--user' => [$this->building->user->id],
                 '--input-source' => [$this->currentInputSource->short],
                 '--step-short' => $stepShortsToRecalculate,
-                // we are doing a full recalculate, we want to keep the user his advices organised as they are at the moment.
                 '--with-old-advices' => false,
             ]);
         }

--- a/app/Listeners/RecalculateToolForUserListener.php
+++ b/app/Listeners/RecalculateToolForUserListener.php
@@ -5,8 +5,6 @@ namespace App\Listeners;
 use App\Console\Commands\Tool\RecalculateForUser;
 use App\Helpers\HoomdossierSession;
 use App\Models\InputSource;
-use App\Models\Notification;
-use App\Models\Step;
 use Illuminate\Support\Facades\Artisan;
 
 class RecalculateToolForUserListener


### PR DESCRIPTION
Lucky me, a change to the tool:recalculate wasn't needed. Fixed the issue in the QuickScan/Form.php itself.

- Previously the recalculate for specific steps would be triggerd when the master had completed the quick scan, however in some cases there were no specific steps to recalculate (summary page eg). This would result in empty step-shorts being given to the tool:recalculate command, when no steps provided the command would just get all steps to recaluclate. So now we check if the master has completed the quick scan and if the step shorts to recalculate are not empty.