### PR TITLE
Fixes issue where it wasnt possible to upload the same file twice.

### DIFF
--- a/app/Http/Controllers/Cooperation/Admin/Cooperation/CooperationAdmin/SettingsController.php
+++ b/app/Http/Controllers/Cooperation/Admin/Cooperation/CooperationAdmin/SettingsController.php
@@ -41,7 +41,7 @@ class SettingsController extends Controller
 
                 // Upload the new media, replace file if it already exists
                 $media = MediaUploader::fromSource($file)
-                    ->onDuplicateReplace()
+                    ->onDuplicateUpdate()
                     ->toDestination('uploads', $cooperation->slug)
                     ->upload();
 


### PR DESCRIPTION
onDuplicateReplace, will replace the old file and media record with new ones, also break associations.

onDuplicateUpdate, will replace the "old" file with new one, update existing media record and maintain the associations to that model.