### PR TITLE
Explicitly set id for include. Otherwise $id will be used which is se…

### DIFF
--- a/resources/views/cooperation/tool/solar-panels/index.blade.php
+++ b/resources/views/cooperation/tool/solar-panels/index.blade.php
@@ -319,7 +319,8 @@
                     </div>
                     <div class="w-full sm:w-1/3">
                         @include('cooperation.layouts.indication-for-costs.co2', [
-                            'translation' => 'solar-panels.index.costs.co2'
+                                'id' => null,
+                                'translation' => 'solar-panels.index.costs.co2'
                         ])
                     </div>
                 </div>
@@ -327,16 +328,19 @@
             <div class="flex flex-row flex-wrap w-full sm:pad-x-6">
                 <div class="w-full sm:w-1/3">
                     @include('cooperation.layouts.indication-for-costs.savings-in-euro',[
-                        'translation' => 'solar-panels.index.savings-in-euro'
+                            'id' => null,
+                            'translation' => 'solar-panels.index.savings-in-euro'
                     ])
                 </div>
                 <div class="w-full sm:w-1/3">
                     @include('cooperation.layouts.indication-for-costs.indicative-costs',[
+                        'id' => null,
                         'translation' => 'solar-panels.index.indicative-costs'
                     ])
                 </div>
                 <div class="w-full sm:w-1/3">
                     @include('cooperation.layouts.indication-for-costs.comparable-rent',[
+                        'id' => null,
                         'translation' => 'solar-panels.index.comparable-rent'
                     ])
                 </div>


### PR DESCRIPTION
…t earlier on. This would break field binding for results display.