### PR TITLE
Feature/heat pump/example building substep fix

### DIFF
--- a/resources/views/cooperation/admin/example-buildings/components/content-table.blade.php
+++ b/resources/views/cooperation/admin/example-buildings/components/content-table.blade.php
@@ -36,41 +36,38 @@
             </td>
         </tr>
         @foreach($step->subSteps as $subStep)
-            <tr>
-                <td colspan="2">
-                    <h4>{{$subStep->name}}</h4>
-                </td>
-            </tr>
-            @foreach($subStep->subSteppables as $subSteppablePivot)
-                @php
-                    $subSteppable = $subSteppablePivot->subSteppable;
-                @endphp
-                @if(! in_array($subSteppable->short, $hideTheseToolQuestions))
+            @if($subStep->toolQuestions->isNotEmpty())
+                <tr>
+                    <td colspan="2">
+                        <h4>{{$subStep->name}}</h4>
+                    </td>
+                </tr>
+                @foreach($subStep->toolQuestions as $toolQuestion)
                     <tr>
                         <td>
-                            {{$subSteppable->name}}
-                            @if(isset($subSteppable->options['min']))
+                            {{$toolQuestion->name}}
+                            @if(isset($toolQuestion->options['min']))
                                 <small>
-                                    Minimaal {{$subSteppable->options['min']}}
+                                    Minimaal {{$toolQuestion->options['min']}}
                                 </small>
                             @endif
-                            @if(isset($subSteppable->options['max']))
+                            @if(isset($toolQuestion->options['max']))
                                 <small>
-                                    Maximaal {{$subSteppable->options['max']}}
+                                    Maximaal {{$toolQuestion->options['max']}}
                                 </small>
                             @endif
                         </td>
                         <td>
 
                             @php
-                                $inputName = ['contents', $buildYear, $subSteppable->short];
+                                $inputName = ['contents', $buildYear, $toolQuestion->short];
                                 $select = false;
                                 $multiple = false;
-                                if(in_array($subSteppablePivot->toolQuestionType->short, ['radio-icon', 'radio-icon-small', 'radio', 'dropdown'])) {
+                                if(in_array($toolQuestion->pivot->toolQuestionType->short, ['radio-icon', 'radio-icon-small', 'radio', 'dropdown'])) {
                                     $select = true;
                                 }
 
-                                if(in_array($subSteppablePivot->toolQuestionType->short, ['checkbox-icon', 'multi-dropdown'])) {
+                                if(in_array($toolQuestion->pivot->toolQuestionType->short, ['checkbox-icon', 'multi-dropdown'])) {
                                     $select = true;
                                     $multiple = true;
                                     // $inputName[] = '*';
@@ -80,13 +77,13 @@
                             @endphp
                             <div class="form-group {{ $errors->has($inputName) ? ' has-error' : '' }}">
 
-                                @if(!empty($subSteppable->unit_of_measure))
+                                @if(!empty($toolQuestion->unit_of_measure))
                                     <div class="input-group">
-                                        <span class="input-group-addon">{{$subSteppable->unit_of_measure}}</span>
+                                        <span class="input-group-addon">{{$toolQuestion->unit_of_measure}}</span>
                                         @endif
                                         @if($select)
                                             @php
-                                                $questionValues = \App\Helpers\QuestionValues\QuestionValue::init($cooperation, $subSteppable)
+                                                $questionValues = \App\Helpers\QuestionValues\QuestionValue::init($cooperation, $toolQuestion)
                                                                    ->answers(collect($contents[$buildYear]))
                                                                    ->getQuestionValues();
                                             @endphp
@@ -116,8 +113,8 @@
                             </div>
                         </td>
                     </tr>
-                @endif
-            @endforeach
+                @endforeach
+            @endif
         @endforeach
     @endforeach
     </tbody>

--- a/resources/views/livewire/cooperation/admin/example-buildings/form.blade.php
+++ b/resources/views/livewire/cooperation/admin/example-buildings/form.blade.php
@@ -77,7 +77,10 @@
 
     <div class="form-group" style="margin-top: 5em;">
         <input type="hidden" name="new" value="0">
-        <button wire:click="save" type="submit" class="btn btn-success btn-block">@lang('cooperation/admin/example-buildings.form.update')</button>
+        <button wire:click="save" wire:loading.attr="disabled" wire:target="save" type="submit"
+                class="btn btn-success btn-block">
+            @lang('cooperation/admin/example-buildings.form.update')
+        </button>
     </div>
 
         <h4>@lang('cooperation/admin/example-buildings.components.contents.title')</h4>


### PR DESCRIPTION
This PR removes the substeps from the example building form if the're empty to reduce clutter