### PR TITLE
Bugfix example building editor.

### DIFF
--- a/app/Http/Livewire/Cooperation/Admin/ExampleBuildings/Form.php
+++ b/app/Http/Livewire/Cooperation/Admin/ExampleBuildings/Form.php
@@ -122,6 +122,9 @@ class Form extends Component
             'exampleBuildingValues.order' => 'nullable|numeric|min:0',
             'contents.new.build_year' => 'nullable|numeric|min:0'
         ]);
+        if (empty($this->exampleBuildingValues['cooperation_id'])) {
+            $this->exampleBuildingValues['cooperation_id'] = null;
+        }
         // update or create
         if ($this->exampleBuilding instanceof ExampleBuilding) {
             $this->exampleBuilding->update($this->exampleBuildingValues);


### PR DESCRIPTION
when the cooperation id is empty, we will assume the user wanted to make it generic. So we set null.