### PR TITLE
Feature/hold custom evaluators

### DIFF
--- a/app/Helpers/Conditions/ConditionEvaluator.php
+++ b/app/Helpers/Conditions/ConditionEvaluator.php
@@ -27,6 +27,8 @@ class ConditionEvaluator
 
     protected bool $explain = false;
 
+    protected array $customResults = [];
+
     /**
      * @param  Building  $building
      *
@@ -200,7 +202,7 @@ class ConditionEvaluator
         // first check if its a custom evaluator
         if ($column == "fn") {
             $customEvaluatorClass = "App\Helpers\Conditions\Evaluators\\{$operator}";
-            return $customEvaluatorClass::evaluate($this->building, $this->inputSource, $value ?? null, $collection);
+            return $this->handleCustomEvaluator($customEvaluatorClass, ($value ?? null), $collection);
         }
 
         // Else check if we should do sub-evaluation
@@ -262,4 +264,18 @@ class ConditionEvaluator
         }
     }
 
+    protected function handleCustomEvaluator(string $customEvaluatorClass, $value, Collection $collection): bool
+    {
+        $operator = class_basename($customEvaluatorClass);
+
+        $override = $this->customResults[$operator] ?? null;
+        /** @var \App\Helpers\Conditions\Evaluators\ShouldEvaluate $customEvaluatorClass */
+        $evaluation = $customEvaluatorClass::init($this->building, $this->inputSource)
+            ->override($override)
+            ->evaluate($value, $collection);
+
+        $this->customResults[$operator] = $evaluation['results'];
+
+        return $evaluation['bool'];
+    }
 }

--- a/app/Helpers/Conditions/ConditionEvaluator.php
+++ b/app/Helpers/Conditions/ConditionEvaluator.php
@@ -268,13 +268,13 @@ class ConditionEvaluator
     {
         $operator = class_basename($customEvaluatorClass);
 
-        $override = $this->customResults[$operator] ?? null;
+        $override = $this->customResults[$operator] ?? [];
         /** @var \App\Helpers\Conditions\Evaluators\ShouldEvaluate $customEvaluatorClass */
         $evaluation = $customEvaluatorClass::init($this->building, $this->inputSource)
             ->override($override)
             ->evaluate($value, $collection);
 
-        $this->customResults[$operator] = $evaluation['results'];
+        $this->customResults[$operator][$evaluation['key']] = $evaluation['results'];
 
         return $evaluation['bool'];
     }

--- a/app/Helpers/Conditions/ConditionEvaluator.php
+++ b/app/Helpers/Conditions/ConditionEvaluator.php
@@ -270,9 +270,9 @@ class ConditionEvaluator
 
         $override = $this->customResults[$operator] ?? [];
         /** @var \App\Helpers\Conditions\Evaluators\ShouldEvaluate $customEvaluatorClass */
-        $evaluation = $customEvaluatorClass::init($this->building, $this->inputSource)
+        $evaluation = $customEvaluatorClass::init($this->building, $this->inputSource, $collection)
             ->override($override)
-            ->evaluate($value, $collection);
+            ->evaluate($value);
 
         $this->customResults[$operator][$evaluation['key']] = $evaluation['results'];
 

--- a/app/Helpers/Conditions/Evaluators/AdviceCategory.php
+++ b/app/Helpers/Conditions/Evaluators/AdviceCategory.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Collection;
 
 class AdviceCategory extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         // Check if the user has the advice, and if so, if it's in the correct category.
         // This requires $value to be an array, where

--- a/app/Helpers/Conditions/Evaluators/AdviceCategory.php
+++ b/app/Helpers/Conditions/Evaluators/AdviceCategory.php
@@ -4,7 +4,6 @@ namespace App\Helpers\Conditions\Evaluators;
 
 use App\Models\MeasureApplication;
 use App\Models\UserActionPlanAdvice;
-use Illuminate\Support\Collection;
 
 class AdviceCategory extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/AdviceCategory.php
+++ b/app/Helpers/Conditions/Evaluators/AdviceCategory.php
@@ -2,16 +2,17 @@
 
 namespace App\Helpers\Conditions\Evaluators;
 
-use App\Models\Building;
-use App\Models\InputSource;
 use App\Models\MeasureApplication;
 use App\Models\UserActionPlanAdvice;
 use Illuminate\Support\Collection;
 
-class AdviceCategory implements ShouldEvaluate
+class AdviceCategory extends ShouldEvaluate
 {
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
         // Check if the user has the advice, and if so, if it's in the correct category.
         // This requires $value to be an array, where
         // 'measure_application' => the short of the measure application,
@@ -21,6 +22,14 @@ class AdviceCategory implements ShouldEvaluate
         $measureApplicationShort = $value['measure_application'];
         $category = $value['category'];
 
+        if (! is_null($this->override)) {
+            $advice = $this->override;
+            return [
+                'results' => $advice,
+                'bool' => $advice instanceof UserActionPlanAdvice && $advice->category === $category,
+            ];
+        }
+
         $measureApplication = MeasureApplication::findByShort($measureApplicationShort);
 
         $advice = $building->user->actionPlanAdvices()
@@ -28,6 +37,9 @@ class AdviceCategory implements ShouldEvaluate
             ->forAdvisable($measureApplication)
             ->first();
 
-        return $advice instanceof UserActionPlanAdvice && $advice->category === $category;
+        return [
+            'results' => $advice,
+            'bool' => $advice instanceof UserActionPlanAdvice && $advice->category === $category,
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/AdviceCategory.php
+++ b/app/Helpers/Conditions/Evaluators/AdviceCategory.php
@@ -22,11 +22,14 @@ class AdviceCategory extends ShouldEvaluate
         $measureApplicationShort = $value['measure_application'];
         $category = $value['category'];
 
-        if (! is_null($this->override)) {
-            $advice = $this->override;
+        $key = md5(json_encode(['measure_application' => $measureApplicationShort]));
+
+        if (! empty($this->override[$key])) {
+            $advice = $this->override[$key];
             return [
                 'results' => $advice,
                 'bool' => $advice instanceof UserActionPlanAdvice && $advice->category === $category,
+                'key' => $key,
             ];
         }
 
@@ -40,6 +43,7 @@ class AdviceCategory extends ShouldEvaluate
         return [
             'results' => $advice,
             'bool' => $advice instanceof UserActionPlanAdvice && $advice->category === $category,
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/AdviceCategory.php
+++ b/app/Helpers/Conditions/Evaluators/AdviceCategory.php
@@ -24,7 +24,7 @@ class AdviceCategory extends ShouldEvaluate
 
         $key = md5(json_encode(['measure_application' => $measureApplicationShort]));
 
-        if (! empty($this->override[$key])) {
+        if (array_key_exists($key, $this->override)) {
             $advice = $this->override[$key];
             return [
                 'results' => $advice,

--- a/app/Helpers/Conditions/Evaluators/BuildingType.php
+++ b/app/Helpers/Conditions/Evaluators/BuildingType.php
@@ -4,7 +4,6 @@ namespace App\Helpers\Conditions\Evaluators;
 
 use App\Models\ToolQuestion;
 use App\Models\BuildingType as BuildingTypeModel;
-use Illuminate\Support\Collection;
 
 class BuildingType extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/BuildingType.php
+++ b/app/Helpers/Conditions/Evaluators/BuildingType.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Collection;
 
 class BuildingType extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         $key = md5(json_encode([null]));
 

--- a/app/Helpers/Conditions/Evaluators/BuildingType.php
+++ b/app/Helpers/Conditions/Evaluators/BuildingType.php
@@ -15,8 +15,8 @@ class BuildingType extends ShouldEvaluate
 
         $key = md5(json_encode([null]));
 
-        if (! empty($this->override[$key])) {
-            $totalCategories = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $totalCategories = $this->override[$key];
             return [
                 'results' => $totalCategories,
                 'bool' => $totalCategories > 1,

--- a/app/Helpers/Conditions/Evaluators/BuildingType.php
+++ b/app/Helpers/Conditions/Evaluators/BuildingType.php
@@ -2,24 +2,38 @@
 
 namespace App\Helpers\Conditions\Evaluators;
 
-use App\Models\Building;
-use App\Models\InputSource;
 use App\Models\ToolQuestion;
 use App\Models\BuildingType as BuildingTypeModel;
 use Illuminate\Support\Collection;
 
-class BuildingType implements ShouldEvaluate
+class BuildingType extends ShouldEvaluate
 {
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
+        if (! is_null($this->override)) {
+            $totalCategories = $this->override;
+            return [
+                'results' => $totalCategories,
+                'bool' => $totalCategories > 1,
+            ];
+        }
+
         // check what kind of category the user has selected, it will determine whether we have to show the building type or not.
         $buildingTypeCategoryId = $building->getAnswer(
             $inputSource,
             ToolQuestion::findByShort('building-type-category')
         );
 
+        $totalCategories = BuildingTypeModel::where('building_type_category_id', $buildingTypeCategoryId)->count();
+
         // only one option would mean that the building type category = building type
         // if there are multiple building types the user has to select a specific one
-        return BuildingTypeModel::where('building_type_category_id', $buildingTypeCategoryId)->count() > 1;
+        return [
+            'results' => $totalCategories,
+            'bool' => $totalCategories > 1,
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/BuildingType.php
+++ b/app/Helpers/Conditions/Evaluators/BuildingType.php
@@ -13,11 +13,14 @@ class BuildingType extends ShouldEvaluate
         $building = $this->building;
         $inputSource = $this->inputSource;
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([null]));
+
+        if (! empty($this->override[$key])) {
             $totalCategories = $this->override;
             return [
                 'results' => $totalCategories,
                 'bool' => $totalCategories > 1,
+                'key' => $key,
             ];
         }
 
@@ -34,6 +37,7 @@ class BuildingType extends ShouldEvaluate
         return [
             'results' => $totalCategories,
             'bool' => $totalCategories > 1,
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
+++ b/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
@@ -4,7 +4,6 @@ namespace App\Helpers\Conditions\Evaluators;
 
 use App\Models\InputSource;
 use App\Models\Step;
-use Illuminate\Support\Collection;
 
 class HasCompletedStep extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
+++ b/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
@@ -2,16 +2,17 @@
 
 namespace App\Helpers\Conditions\Evaluators;
 
-use App\Models\Building;
 use App\Models\InputSource;
 use App\Models\Step;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Log;
 
-class HasCompletedStep implements ShouldEvaluate
+class HasCompletedStep extends ShouldEvaluate
 {
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
         // This evaluator checks if the user has completed one or more steps, for one or more input sources.
         // $value must be an array, where
         // 'step' => one or more step shorts,
@@ -19,15 +20,27 @@ class HasCompletedStep implements ShouldEvaluate
         // 'should_pass' => whether or not this should pass; if set to false, the evaluation will be true if no steps
         // are completed
 
+        $shouldPass = $value['should_pass'] ?? true;
+
+        if (! is_null($this->override)) {
+            $hasCompleted = $this->override;
+            return [
+                'results' => $hasCompleted,
+                'bool' => $shouldPass ? $hasCompleted : ! $hasCompleted,
+            ];
+        }
+
         $steps = Step::findByShorts($value['steps']);
         $inputSources = InputSource::findByShorts($value['input_source_shorts']);
-        $shouldPass = $value['should_pass'] ?? true;
 
         $hasCompleted = $building->completedSteps()->allInputSources()
             ->whereIn('step_id', $steps->pluck('id')->toArray())
             ->whereIn('input_source_id', $inputSources->pluck('id')->toArray())
             ->count() > 0;
 
-        return $shouldPass ? $hasCompleted : ! $hasCompleted;
+        return [
+            'results' => $hasCompleted,
+            'bool' => $shouldPass ? $hasCompleted : ! $hasCompleted,
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
+++ b/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
@@ -29,8 +29,8 @@ class HasCompletedStep extends ShouldEvaluate
             'input_source_shorts' => $inputSourceShorts,
         ]));
 
-        if (! empty($this->override[$key])) {
-            $hasCompleted = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $hasCompleted = $this->override[$key];
             return [
                 'results' => $hasCompleted,
                 'bool' => $shouldPass ? $hasCompleted : ! $hasCompleted,

--- a/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
+++ b/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
@@ -20,18 +20,26 @@ class HasCompletedStep extends ShouldEvaluate
         // 'should_pass' => whether or not this should pass; if set to false, the evaluation will be true if no steps
         // are completed
 
+        $stepShorts = $value['steps'];
+        $inputSourceShorts = $value['input_source_shorts'];
         $shouldPass = $value['should_pass'] ?? true;
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([
+            'step_shorts' => $stepShorts,
+            'input_source_shorts' => $inputSourceShorts,
+        ]));
+
+        if (! empty($this->override[$key])) {
             $hasCompleted = $this->override;
             return [
                 'results' => $hasCompleted,
                 'bool' => $shouldPass ? $hasCompleted : ! $hasCompleted,
+                'key' => $key,
             ];
         }
 
-        $steps = Step::findByShorts($value['steps']);
-        $inputSources = InputSource::findByShorts($value['input_source_shorts']);
+        $steps = Step::findByShorts($stepShorts);
+        $inputSources = InputSource::findByShorts($inputSourceShorts);
 
         $hasCompleted = $building->completedSteps()->allInputSources()
             ->whereIn('step_id', $steps->pluck('id')->toArray())
@@ -41,6 +49,7 @@ class HasCompletedStep extends ShouldEvaluate
         return [
             'results' => $hasCompleted,
             'bool' => $shouldPass ? $hasCompleted : ! $hasCompleted,
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
+++ b/app/Helpers/Conditions/Evaluators/HasCompletedStep.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Collection;
 
 class HasCompletedStep extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         // This evaluator checks if the user has completed one or more steps, for one or more input sources.
         // $value must be an array, where

--- a/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
@@ -3,7 +3,6 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\HighEfficiencyBoiler;
-use Illuminate\Support\Collection;
 
 class HrBoilerAdvice extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Collection;
 
 class HrBoilerAdvice extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         // This evaluator checks if the boiler_advice is returned in the calculation. This advice tells the user
         // that they won't receive much efficiency improvement because they already have a high quality HR-boiler

--- a/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
@@ -15,11 +15,14 @@ class HrBoilerAdvice extends ShouldEvaluate
         // This evaluator checks if the boiler_advice is returned in the calculation. This advice tells the user
         // that they won't receive much efficiency improvement because they already have a high quality HR-boiler
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([null]));
+
+        if (! empty($this->override[$key])) {
             $results = $this->override;
             return [
                 'results' => $results,
                 'bool' => array_key_exists('boiler_advice', $results),
+                'key' => $key,
             ];
         }
 
@@ -28,6 +31,7 @@ class HrBoilerAdvice extends ShouldEvaluate
         return [
             'results' => $results,
             'bool' => array_key_exists('boiler_advice', $results),
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
@@ -17,8 +17,8 @@ class HrBoilerAdvice extends ShouldEvaluate
 
         $key = md5(json_encode([null]));
 
-        if (! empty($this->override[$key])) {
-            $results = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $results = $this->override[$key];
             return [
                 'results' => $results,
                 'bool' => array_key_exists('boiler_advice', $results),

--- a/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/HrBoilerAdvice.php
@@ -3,22 +3,31 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\HighEfficiencyBoiler;
-use App\Models\Building;
-use App\Models\InputSource;
-use App\Traits\HasDynamicAnswers;
 use Illuminate\Support\Collection;
 
-class HrBoilerAdvice implements ShouldEvaluate
+class HrBoilerAdvice extends ShouldEvaluate
 {
-    use HasDynamicAnswers;
-
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
         // This evaluator checks if the boiler_advice is returned in the calculation. This advice tells the user
         // that they won't receive much efficiency improvement because they already have a high quality HR-boiler
 
+        if (! is_null($this->override)) {
+            $results = $this->override;
+            return [
+                'results' => $results,
+                'bool' => array_key_exists('boiler_advice', $results),
+            ];
+        }
+
         $results = HighEfficiencyBoiler::calculate($building, $inputSource, $answers);
 
-        return array_key_exists('boiler_advice', $results);
+        return [
+            'results' => $results,
+            'bool' => array_key_exists('boiler_advice', $results),
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Collection;
 
 class InsulationAdvice extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         // This evaluator checks if a given advice is returned by the insulation score. This tells the user
         // they should improve certain aspects of their home before considering a heat pump, because it might not

--- a/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
@@ -3,7 +3,6 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\HeatPump;
-use Illuminate\Support\Collection;
 
 class InsulationAdvice extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
@@ -18,8 +18,8 @@ class InsulationAdvice extends ShouldEvaluate
 
         $key = md5(json_encode([null]));
 
-        if (! empty($this->override[$key])) {
-            $results = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $results = $this->override[$key];
             return [
                 'results' => $results,
                 'bool' => in_array($value, $results),

--- a/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
@@ -16,11 +16,14 @@ class InsulationAdvice extends ShouldEvaluate
         // they should improve certain aspects of their home before considering a heat pump, because it might not
         // perform to ideal standards.
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([null]));
+
+        if (! empty($this->override[$key])) {
             $results = $this->override;
             return [
                 'results' => $results,
                 'bool' => in_array($value, $results),
+                'key' => $key,
             ];
         }
 
@@ -34,6 +37,7 @@ class InsulationAdvice extends ShouldEvaluate
         return [
             'results' => $results,
             'bool' => in_array($value, $results),
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationAdvice.php
@@ -3,23 +3,37 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\HeatPump;
-use App\Models\Building;
-use App\Models\InputSource;
 use Illuminate\Support\Collection;
 
-class InsulationAdvice implements ShouldEvaluate
+class InsulationAdvice extends ShouldEvaluate
 {
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
         // This evaluator checks if a given advice is returned by the insulation score. This tells the user
         // they should improve certain aspects of their home before considering a heat pump, because it might not
         // perform to ideal standards.
+
+        if (! is_null($this->override)) {
+            $results = $this->override;
+            return [
+                'results' => $results,
+                'bool' => in_array($value, $results),
+            ];
+        }
 
         $calculator = new HeatPump($building, $inputSource, $answers);
 
         // We don't need the return value, but the method sets the advices
         $calculator->insulationScore();
 
-        return in_array($value, $calculator->getAdvices());
+        $results = $calculator->getAdvices();
+
+        return [
+            'results' => $results,
+            'bool' => in_array($value, $results),
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/InsulationScore.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationScore.php
@@ -15,11 +15,14 @@ class InsulationScore extends ShouldEvaluate
         // This evaluator checks if the user's insulation is good enough to install a heat pump.
         // $value is expected as float/int.
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([null]));
+
+        if (! empty($this->override[$key])) {
             $results = $this->override;
             return [
                 'results' => $results,
                 'bool' => $results < $value,
+                'key' => $key,
             ];
         }
 
@@ -28,6 +31,7 @@ class InsulationScore extends ShouldEvaluate
         return [
             'results' => $results,
             'bool' => $results < $value,
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/InsulationScore.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationScore.php
@@ -17,8 +17,8 @@ class InsulationScore extends ShouldEvaluate
 
         $key = md5(json_encode([null]));
 
-        if (! empty($this->override[$key])) {
-            $results = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $results = $this->override[$key];
             return [
                 'results' => $results,
                 'bool' => $results < $value,

--- a/app/Helpers/Conditions/Evaluators/InsulationScore.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationScore.php
@@ -3,17 +3,31 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\HeatPump;
-use App\Models\Building;
-use App\Models\InputSource;
 use Illuminate\Support\Collection;
 
-class InsulationScore implements ShouldEvaluate
+class InsulationScore extends ShouldEvaluate
 {
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
         // This evaluator checks if the user's insulation is good enough to install a heat pump.
         // $value is expected as float/int.
 
-        return HeatPump::init($building, $inputSource, $answers)->insulationScore() < $value;
+        if (! is_null($this->override)) {
+            $results = $this->override;
+            return [
+                'results' => $results,
+                'bool' => $results < $value,
+            ];
+        }
+
+        $results = HeatPump::init($building, $inputSource, $answers)->insulationScore();
+
+        return [
+            'results' => $results,
+            'bool' => $results < $value,
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/InsulationScore.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationScore.php
@@ -3,7 +3,6 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\HeatPump;
-use Illuminate\Support\Collection;
 
 class InsulationScore extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/InsulationScore.php
+++ b/app/Helpers/Conditions/Evaluators/InsulationScore.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Collection;
 
 class InsulationScore extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         // This evaluator checks if the user's insulation is good enough to install a heat pump.
         // $value is expected as float/int.

--- a/app/Helpers/Conditions/Evaluators/ShouldEvaluate.php
+++ b/app/Helpers/Conditions/Evaluators/ShouldEvaluate.php
@@ -4,9 +4,28 @@ namespace App\Helpers\Conditions\Evaluators;
 
 use App\Models\InputSource;
 use App\Models\Building;
+use App\Traits\FluentCaller;
 use Illuminate\Support\Collection;
 
-interface ShouldEvaluate
+abstract class ShouldEvaluate
 {
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool;
+    use FluentCaller;
+
+    protected Building $building;
+    protected InputSource $inputSource;
+    protected $override = null;
+
+    public function __construct(Building $building, InputSource $inputSource)
+    {
+        $this->building = $building;
+        $this->inputSource = $inputSource;
+    }
+
+    public function override($override): self
+    {
+        $this->override = $override;
+        return $this;
+    }
+
+    abstract public function evaluate($value = null, ?Collection $answers = null): array;
 }

--- a/app/Helpers/Conditions/Evaluators/ShouldEvaluate.php
+++ b/app/Helpers/Conditions/Evaluators/ShouldEvaluate.php
@@ -5,20 +5,21 @@ namespace App\Helpers\Conditions\Evaluators;
 use App\Models\InputSource;
 use App\Models\Building;
 use App\Traits\FluentCaller;
+use App\Traits\HasDynamicAnswers;
 use Illuminate\Support\Collection;
 
 abstract class ShouldEvaluate
 {
-    use FluentCaller;
+    use FluentCaller,
+        HasDynamicAnswers;
 
-    protected Building $building;
-    protected InputSource $inputSource;
     protected array $override = [];
 
-    public function __construct(Building $building, InputSource $inputSource)
+    public function __construct(Building $building, InputSource $inputSource, ?Collection $answers = null)
     {
         $this->building = $building;
         $this->inputSource = $inputSource;
+        $this->answers = $answers;
     }
 
     public function override($override): self
@@ -27,5 +28,5 @@ abstract class ShouldEvaluate
         return $this;
     }
 
-    abstract public function evaluate($value = null, ?Collection $answers = null): array;
+    abstract public function evaluate($value = null): array;
 }

--- a/app/Helpers/Conditions/Evaluators/ShouldEvaluate.php
+++ b/app/Helpers/Conditions/Evaluators/ShouldEvaluate.php
@@ -13,7 +13,7 @@ abstract class ShouldEvaluate
 
     protected Building $building;
     protected InputSource $inputSource;
-    protected $override = null;
+    protected array $override = [];
 
     public function __construct(Building $building, InputSource $inputSource)
     {

--- a/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
+++ b/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Collection;
 
 class SpecificExampleBuilding extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         $key = md5(json_encode([null]));
 

--- a/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
+++ b/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
@@ -13,11 +13,14 @@ class SpecificExampleBuilding extends ShouldEvaluate
         $building = $this->building;
         $inputSource = $this->inputSource;
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([null]));
+
+        if (! empty($this->override[$key])) {
             $results = $this->override;
             return [
                 'results' => $results,
                 'bool' => $results['specific_exists'] || $results['generic_total'] > 1,
+                'key' => $key,
             ];
         }
 
@@ -44,6 +47,7 @@ class SpecificExampleBuilding extends ShouldEvaluate
         return [
             'results' => $results,
             'bool' => $results['specific_exists'] || $results['generic_total'] > 1,
+            'key' => $key,
         ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
+++ b/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
@@ -15,8 +15,8 @@ class SpecificExampleBuilding extends ShouldEvaluate
 
         $key = md5(json_encode([null]));
 
-        if (! empty($this->override[$key])) {
-            $results = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $results = $this->override[$key];
             return [
                 'results' => $results,
                 'bool' => $results['specific_exists'] || $results['generic_total'] > 1,

--- a/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
+++ b/app/Helpers/Conditions/Evaluators/SpecificExampleBuilding.php
@@ -4,7 +4,6 @@ namespace App\Helpers\Conditions\Evaluators;
 
 use App\Models\ExampleBuilding;
 use App\Models\ToolQuestion;
-use Illuminate\Support\Collection;
 
 class SpecificExampleBuilding extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
+++ b/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
@@ -17,8 +17,8 @@ class SunBoilerPerformance extends ShouldEvaluate
 
         $key = md5(json_encode([null]));
 
-        if (! empty($this->override[$key])) {
-            $results = $this->override;
+        if (array_key_exists($key, $this->override)) {
+            $results = $this->override[$key];
             return [
                 'results' => $results,
                 'bool' => data_get($results, 'performance.alert') === $value,

--- a/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
+++ b/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
@@ -3,7 +3,6 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\Heater;
-use Illuminate\Support\Collection;
 
 class SunBoilerPerformance extends ShouldEvaluate
 {

--- a/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
+++ b/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Collection;
 
 class SunBoilerPerformance extends ShouldEvaluate
 {
-    public function evaluate($value = null, ?Collection $answers = null): array
+    public function evaluate($value = null): array
     {
         $building = $this->building;
         $inputSource = $this->inputSource;
+        $answers = $this->answers;
 
         // This evaluator checks the performance for the sun-boiler in the user's situation. The calculation
         // returns a given color which defines the performance.

--- a/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
+++ b/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
@@ -3,19 +3,25 @@
 namespace App\Helpers\Conditions\Evaluators;
 
 use App\Calculations\Heater;
-use App\Models\Building;
-use App\Models\InputSource;
-use App\Traits\HasDynamicAnswers;
 use Illuminate\Support\Collection;
 
-class SunBoilerPerformance implements ShouldEvaluate
+class SunBoilerPerformance extends ShouldEvaluate
 {
-    use HasDynamicAnswers;
-
-    public static function evaluate(Building $building, InputSource $inputSource, $value = null, ?Collection $answers = null): bool
+    public function evaluate($value = null, ?Collection $answers = null): array
     {
+        $building = $this->building;
+        $inputSource = $this->inputSource;
+
         // This evaluator checks the performance for the sun-boiler in the user's situation. The calculation
         // returns a given color which defines the performance.
+
+        if (! is_null($this->override)) {
+            $results = $this->override;
+            return [
+                'results' => $results,
+                'bool' => data_get($results, 'performance.alert') === $value,
+            ];
+        }
 
         $results = Heater::calculate(
             $building,
@@ -23,6 +29,9 @@ class SunBoilerPerformance implements ShouldEvaluate
             $answers,
         );
 
-        return data_get($results, 'performance.alert') === $value;
+        return [
+            'results' => $results,
+            'bool' => data_get($results, 'performance.alert') === $value,
+        ];
     }
 }

--- a/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
+++ b/app/Helpers/Conditions/Evaluators/SunBoilerPerformance.php
@@ -15,11 +15,14 @@ class SunBoilerPerformance extends ShouldEvaluate
         // This evaluator checks the performance for the sun-boiler in the user's situation. The calculation
         // returns a given color which defines the performance.
 
-        if (! is_null($this->override)) {
+        $key = md5(json_encode([null]));
+
+        if (! empty($this->override[$key])) {
             $results = $this->override;
             return [
                 'results' => $results,
                 'bool' => data_get($results, 'performance.alert') === $value,
+                'key' => $key,
             ];
         }
 
@@ -32,6 +35,7 @@ class SunBoilerPerformance extends ShouldEvaluate
         return [
             'results' => $results,
             'bool' => data_get($results, 'performance.alert') === $value,
+            'key' => $key,
         ];
     }
 }

--- a/docs/code-business-logic/condition-evaluator.md
+++ b/docs/code-business-logic/condition-evaluator.md
@@ -136,3 +136,9 @@ case, the columns are as follows:
 
 Just like the main evaluator, a building and input source are passed to these evaluators. However, these evaluators 
 also accept a nullable value, as well as a `Collection` of answers, to allow for dynamic and complex logic.
+
+##### Developer note
+The custom evaluators share their results with the condition evaluator so any next checks of the same custom evaluator 
+will allow the earlier result to be checked. This saves a ton of unnecessary duplicate processes. The custom evaluator 
+will return an `array` containing `results`, which are the results of the evaluation, `bool` which is whether the
+evaluation has passed and `key` which is an MD5 to differentiate between custom evaluators with different parameters.


### PR DESCRIPTION
This PR makes a change to the condition evaluator so it saves the results of custom evaluators during its runtime. This means that we don't have to re-evaluate the same stuff over and over again, significantly improving query count on larger sets of evaluation. Just for the alerts, 148 queries are saved.