### PR TITLE
Feature/subsidy/dont force 0

### DIFF
--- a/app/Helpers/DataTypes/Caster.php
+++ b/app/Helpers/DataTypes/Caster.php
@@ -22,10 +22,16 @@ class Caster
     protected $value;
     protected bool $force = false;
 
-    public function __construct(string $dataType, $value)
+    public function dataType(string $dataType): self
     {
         $this->dataType = $dataType;
+        return $this;
+    }
+
+    public function value($value): self
+    {
         $this->value = $value;
+        return $this;
     }
 
     public function force(): self
@@ -87,6 +93,9 @@ class Caster
     {
         // if needed, the cast can be applied per datatype. (like the forUser method)
         $value = $this->value;
+        if (is_null($value) && ! $this->force) {
+            return null;
+        }
 
         switch ($this->dataType) {
             case static::INT:

--- a/app/Helpers/DataTypes/Caster.php
+++ b/app/Helpers/DataTypes/Caster.php
@@ -34,6 +34,11 @@ class Caster
         return $this;
     }
 
+    /**
+     * Force defines whether or not converting data should be forced if the value is null.
+     *
+     * @return $this
+     */
     public function force(): self
     {
         $this->force = true;
@@ -56,12 +61,12 @@ class Caster
                 $this->value = (string) $this->value;
                 break;
 
-            case static::INT_5:
-                $this->value = (int) NumberFormatter::round((float) $this->value, 5);
-                break;
-
             case static::INT:
                 $this->value = (int) round((float) $this->value);
+                break;
+
+            case static::INT_5:
+                $this->value = (int) NumberFormatter::round((float) $this->value, 5);
                 break;
 
             case static::FLOAT:
@@ -99,12 +104,12 @@ class Caster
 
         switch ($this->dataType) {
             case static::INT:
+                // Note that the dot is replaced with nothing. We expect a Dutch format.
                 $value = (int) NumberFormatter::mathableFormat(str_replace('.', '', ($value ?? 0)), 0);
                 break;
             case static::FLOAT:
+                // Note that the dot is replaced with nothing. We expect a Dutch format.
                 $value = (float) NumberFormatter::mathableFormat(str_replace('.', '', ($value ?? 0)), 2);
-                break;
-            default:
                 break;
         }
 
@@ -123,11 +128,8 @@ class Caster
         }
 
         switch ($this->dataType) {
-            case static::INT_5:
-                $value = NumberFormatter::formatNumberForUser($value, true, false);
-                break;
-
             case static::INT:
+            case static::INT_5:
                 $value = NumberFormatter::formatNumberForUser($value, true, false);
                 break;
 

--- a/app/Helpers/ToolQuestionHelper.php
+++ b/app/Helpers/ToolQuestionHelper.php
@@ -326,9 +326,15 @@ class ToolQuestionHelper
 
             // Format answers
             if (in_array($toolQuestion->data_type, [Caster::INT, Caster::FLOAT])) {
-                $humanReadableAnswer = Caster::init($toolQuestion->data_type, $humanReadableAnswer)->getFormatForUser();
+                $humanReadableAnswer = Caster::init()
+                    ->dataType($toolQuestion->data_type)
+                    ->value($humanReadableAnswer)
+                    ->getFormatForUser();
             } elseif ($toolQuestion->data_type === Caster::JSON) {
-                $humanReadableAnswerArray = Caster::init($toolQuestion->data_type, $humanReadableAnswer)->getCast();
+                $humanReadableAnswerArray = Caster::init()
+                    ->dataType($toolQuestion->data_type)
+                    ->value($humanReadableAnswer)
+                    ->getCast();
                 $humanReadableAnswer = [];
                 foreach ($toolQuestion->options as $option) {
                     $humanReadableAnswer[$option['name']] = $humanReadableAnswerArray[$option['short']];

--- a/app/Http/Livewire/Cooperation/Admin/ExampleBuildings/Form.php
+++ b/app/Http/Livewire/Cooperation/Admin/ExampleBuildings/Form.php
@@ -11,7 +11,6 @@ use App\Models\Cooperation;
 use App\Models\ExampleBuilding;
 use App\Models\Step;
 use App\Rules\LanguageRequired;
-use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
 use Illuminate\Support\Facades\Session;
 
@@ -87,7 +86,10 @@ class Form extends Component
                 foreach ($content as $toolQuestionShort => $value) {
                     if (array_key_exists($toolQuestionShort, $this->toolQuestionDataType)) {
                         if ($this->toolQuestionDataType[$toolQuestionShort] === \App\Helpers\DataTypes\Caster::FLOAT) {
-                            $content[$toolQuestionShort] = Caster::init(Caster::FLOAT, $value)->getFormatForUser();
+                            $content[$toolQuestionShort] = Caster::init()
+                                ->dataType(Caster::FLOAT)
+                                ->value($value)
+                                ->getFormatForUser();
                         }
                     } else {
                         // If it's not found it means it should not be set
@@ -191,7 +193,10 @@ class Form extends Component
 
                     // cast the value to a database value (a int)
                     if ($this->toolQuestionDataType[$toolQuestionShort] === Caster::FLOAT) {
-                        $content[$toolQuestionShort] = Caster::init(Caster::FLOAT, $value)->reverseFormatted();
+                        $content[$toolQuestionShort] = Caster::init()
+                            ->dataType(Caster::FLOAT)
+                            ->value($value)
+                            ->reverseFormatted();
                     }
                 }
             }

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/ExpertScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/ExpertScan/Form.php
@@ -148,9 +148,10 @@ class Form extends Component
                     // this is horseshit but is necessary; the sub steppable component reverseFormats and goes back to human readable
                     // so when we actually start saving it we have to format it one more time
                     if ($toolQuestion->data_type === Caster::FLOAT) {
-                        $givenAnswer = Caster::init(
-                            $toolQuestion->data_type, $givenAnswer
-                        )->reverseFormatted();
+                        $givenAnswer = Caster::init()
+                            ->dataType($toolQuestion->data_type)
+                            ->value($givenAnswer)
+                            ->reverseFormatted();
                     }
 
                     // TODO: this is a horrible way to trace dirty answers
@@ -260,7 +261,11 @@ class Form extends Component
 
                 // Could be an unused result
                 if ($result instanceof ToolCalculationResult) {
-                    Arr::set($performedCalculations, $resultShort, Caster::init($result->data_type, $value)->getFormatForUser());
+                    Arr::set(
+                        $performedCalculations,
+                        $resultShort,
+                        Caster::init()->dataType($result->data_type)->value($value)->getFormatForUser()
+                    );
                 }
             }
 

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/ExpertScan/SubSteppable.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/ExpertScan/SubSteppable.php
@@ -112,9 +112,10 @@ class SubSteppable extends Scannable
         // Before we can validate (and save), we must reset the formatting from text to mathable
         foreach ($this->toolQuestions as $toolQuestion) {
             if ($toolQuestion->data_type === Caster::FLOAT) {
-                $this->filledInAnswers[$toolQuestion->short] = Caster::init(
-                    $toolQuestion->data_type, $this->filledInAnswers[$toolQuestion->short]
-                )->reverseFormatted();
+                $this->filledInAnswers[$toolQuestion->short] = Caster::init()
+                    ->dataType($toolQuestion->data_type)
+                    ->value($this->filledInAnswers[$toolQuestion->short])
+                    ->reverseFormatted();
             }
         }
 
@@ -135,9 +136,10 @@ class SubSteppable extends Scannable
             Log::debug("Sub step {$this->subStep->name} " . ($validator->fails() ? 'fails validation' : 'passes validation'));
             foreach ($this->toolQuestions as $toolQuestion) {
                 if (in_array($toolQuestion->data_type, [Caster::INT, Caster::FLOAT])) {
-                    $this->filledInAnswers[$toolQuestion->short] = Caster::init(
-                        $toolQuestion->data_type, $this->filledInAnswers[$toolQuestion->short]
-                    )->getFormatForUser();
+                    $this->filledInAnswers[$toolQuestion->short] = Caster::init()
+                        ->dataType($toolQuestion->data_type)
+                        ->value($this->filledInAnswers[$toolQuestion->short])
+                        ->getFormatForUser();
                 }
             }
             if ($validator->fails()) {

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/Scannable.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/Scannable.php
@@ -100,7 +100,8 @@ abstract class Scannable extends Component
             if ($toolQuestion instanceof ToolQuestion) {
                 // If it's an INT, we want to ensure the value set is also an INT
                 if ($toolQuestion->data_type === Caster::INT) {
-                    $value = Caster::init(Caster::INT, Caster::init(Caster::INT, $value)->reverseFormatted())->getFormatForUser();
+                    $caster = Caster::init()->dataType(Caster::INT)->value($value);
+                    $value = $caster->value($caster->reverseFormatted())->getFormatForUser();
                     $this->filledInAnswers[$toolQuestionShort] = $value;
                 }
             }
@@ -207,7 +208,7 @@ abstract class Scannable extends Component
                 $toolQuestion = $this->toolQuestions->where('short', $toolQuestionShort)->first();
                 // Validator failed, let's put it back as the user format
                 if (in_array($toolQuestion->data_type, [Caster::INT, Caster::FLOAT])) {
-                    $this->filledInAnswers[$toolQuestion->short] = Caster::init($toolQuestion->data_type, $this->filledInAnswers[$toolQuestion->short])->getFormatForUser();
+                    $this->filledInAnswers[$toolQuestion->short] = Caster::init()->dataType($toolQuestion->data_type)->value($this->filledInAnswers[$toolQuestion->short])->getFormatForUser();
                 }
 
                 // TODO: Check if this should be subject to $this->automaticallyEvaluate
@@ -304,7 +305,10 @@ abstract class Scannable extends Component
                         // Before we would set sliders and text answers differently. Now, because they are mapped by the
                         // same (by data type) it could be that value is not set.
                         $answer = $answerForInputSource ?? $toolQuestion->options['value'] ?? 0;
-                        $answerForInputSource = Caster::init($toolQuestion->data_type, $answer)->getFormatForUser();
+                        $answerForInputSource = Caster::init()
+                            ->dataType($toolQuestion->data_type)
+                            ->value($answer)
+                            ->getFormatForUser();
                     }
 
                     $this->filledInAnswers[$toolQuestion->short] = $answerForInputSource;

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/Scannable.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/Scannable.php
@@ -100,6 +100,15 @@ abstract class Scannable extends Component
             if ($toolQuestion instanceof ToolQuestion) {
                 // If it's an INT, we want to ensure the value set is also an INT
                 if ($toolQuestion->data_type === Caster::INT) {
+                    // So, if a value is an empty string, we will nullify it. If it's an empty string, it will get cast
+                    // to a 0. We don't want that. If we do that, a user can never "reset" their answer. It will only
+                    // ever be an empty string, when it's user input.
+
+                    if ($value === '') {
+                        $value = null;
+                        $this->fill([$field => $value]);
+                    }
+
                     $caster = Caster::init()->dataType(Caster::INT)->value($value);
                     $value = $caster->value($caster->reverseFormatted())->getFormatForUser();
                     $this->filledInAnswers[$toolQuestionShort] = $value;
@@ -260,7 +269,6 @@ abstract class Scannable extends Component
     {
         // base key where every answer is stored
         foreach ($this->toolQuestions as $index => $toolQuestion) {
-
             // We get all answers, including for the master. This way we reduce amount of queries needed.
             $this->filledInAnswersForAllInputSources[$toolQuestion->short] = $this->building->getAnswerForAllInputSources($toolQuestion, true);
 
@@ -304,7 +312,7 @@ abstract class Scannable extends Component
                     if (in_array($toolQuestion->data_type, [Caster::INT, Caster::FLOAT])) {
                         // Before we would set sliders and text answers differently. Now, because they are mapped by the
                         // same (by data type) it could be that value is not set.
-                        $answer = $answerForInputSource ?? $toolQuestion->options['value'] ?? 0;
+                        $answer = $answerForInputSource ?? $toolQuestion->options['value'] ?? null;
                         $answerForInputSource = Caster::init()
                             ->dataType($toolQuestion->data_type)
                             ->value($answer)

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/SimpleScan/Form.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/SimpleScan/Form.php
@@ -71,9 +71,10 @@ class Form extends Scannable
         // Before we can validate (and save), we must reset the formatting from text to mathable
         foreach ($this->toolQuestions as $toolQuestion) {
             if ($toolQuestion->data_type === Caster::FLOAT) {
-                $this->filledInAnswers[$toolQuestion->short] = Caster::init(
-                    $toolQuestion->data_type, $this->filledInAnswers[$toolQuestion->short]
-                )->reverseFormatted();
+                $this->filledInAnswers[$toolQuestion->short] = Caster::init()
+                    ->dataType($toolQuestion->data_type)
+                    ->value($this->filledInAnswers[$toolQuestion->short])
+                    ->reverseFormatted();
             }
         }
 
@@ -95,7 +96,10 @@ class Form extends Scannable
                 // Validator failed, let's put it back as the user format
                 foreach ($this->toolQuestions as $toolQuestion) {
                     if (in_array($toolQuestion->data_type, [Caster::INT, Caster::FLOAT])) {
-                        $this->filledInAnswers[$toolQuestion->short] = Caster::init($toolQuestion->data_type, $this->filledInAnswers[$toolQuestion->short])->getFormatForUser();
+                        $this->filledInAnswers[$toolQuestion->short] = Caster::init()
+                            ->dataType($toolQuestion->data_type)
+                            ->value($this->filledInAnswers[$toolQuestion->short])
+                            ->getFormatForUser();
                     }
                 }
 

--- a/app/Http/Livewire/Cooperation/Frontend/Tool/SimpleScan/MyPlan/CalculationsTable.php
+++ b/app/Http/Livewire/Cooperation/Frontend/Tool/SimpleScan/MyPlan/CalculationsTable.php
@@ -114,9 +114,10 @@ class CalculationsTable extends Component
                     $this->tableData[$toolQuestion->short]['source'] = $answers[$toolQuestion->id][$firstKey]['input_source_name'] ?? null;
 
                     if (in_array($toolQuestion->data_type, [Caster::INT, Caster::INT_5, Caster::FLOAT])) {
-                        $this->tableData[$toolQuestion->short]['value'] = Caster::init(
-                            $toolQuestion->data_type, $this->tableData[$toolQuestion->short]['value']
-                        )->getFormatForUser();
+                        $this->tableData[$toolQuestion->short]['value'] = Caster::init()
+                            ->dataType($toolQuestion->data_type)
+                            ->value($this->tableData[$toolQuestion->short]['value'])
+                            ->getFormatForUser();
                     }
 
                     if (! empty($toolQuestion->unit_of_measure)) {

--- a/resources/views/cooperation/frontend/layouts/parts/navbar.blade.php
+++ b/resources/views/cooperation/frontend/layouts/parts/navbar.blade.php
@@ -167,6 +167,14 @@
                            class="in-text">
                             @lang('woningdossier.cooperation.navbar.my-account')
                         </a>
+
+                        @if(app()->isLocal())
+                            <p>
+                                B: {{ $building->id }}
+                                <br>
+                                U: {{ $building->user->id }}
+                            </p>
+                        @endif
                     </li>
                     <li>
                         <a href="{{ route('cooperation.privacy.index', compact('cooperation')) }}"

--- a/tests/Unit/app/Helpers/DataTypes/CasterTest.php
+++ b/tests/Unit/app/Helpers/DataTypes/CasterTest.php
@@ -119,8 +119,8 @@ class CasterTest extends TestCase
 
     public function reverseFormattedProvider()
     {
-        // Provider note: The code only reverse formats ints and floats, as they are the only random user input.
-        // Therefore, this test is limited to these 2 only (in detail).
+        // Provider note: The code only reverse formats ints and floats, as they are the only  user input that require
+        // formatting. Therefore, this test is limited to these 2 only (in detail).
         return [
             // Test cases to prove the noted point.
             [Caster::STRING, 10, false, 10],
@@ -189,7 +189,7 @@ class CasterTest extends TestCase
             [Caster::INT_5, '10', false, '10'],
             [Caster::INT_5, '10.3', false, '10'],
             [Caster::INT_5, '10,3', false, '10'],
-            [Caster::INT_5, '10.73', false, '11'],
+            [Caster::INT_5, '10.73', false, '10'],
             [Caster::INT_5, '12.73', false, '15'],
             [Caster::INT_5, '13', false, '15'],
             [Caster::INT_5, '10,73', false, '10'],

--- a/tests/Unit/app/Helpers/DataTypes/CasterTest.php
+++ b/tests/Unit/app/Helpers/DataTypes/CasterTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\app\Helpers\DataTypes;
+
+use App\Helpers\DataTypes\Caster;
+use Tests\TestCase;
+
+class CasterTest extends TestCase
+{
+    public function valueIsCorrectlyCastedProvider()
+    {
+        return [
+            [Caster::STRING, 10, false, '10'],
+            [Caster::STRING, '10', false, '10'],
+            [Caster::STRING, 'gibberish', false, 'gibberish'],
+            [Caster::STRING, null, false, ''],
+            [Caster::STRING, true, false, '1'],
+            [Caster::STRING, false, false, ''],
+            [Caster::INT, 'gibberish', false, 0],
+            [Caster::INT, '10', false, 10],
+            [Caster::INT, '10.3', false, 10],
+            [Caster::INT, '10.5', false, 11],
+            [Caster::INT, '10,5', false, 10],
+            [Caster::INT, '-10', false, -10],
+            [Caster::INT, '-10.5', false, -11],
+            [Caster::INT, '-0', false, 0],
+            [Caster::INT, 13, false, 13],
+            [Caster::INT, 13.7, false, 14],
+            [Caster::INT, 13.7, false, 14],
+            [Caster::INT, -13.2, false, -13],
+            [Caster::INT, -13.7, false, -14],
+            [Caster::INT, null, false, null],
+            [Caster::INT, null, true, 0],
+            [Caster::INT, true, false, 1],
+            [Caster::INT, false, false, 0],
+            [Caster::INT_5, 'gibberish', false, 0],
+            [Caster::INT_5, '10', false, 10],
+            [Caster::INT_5, '10.3', false, 10],
+            [Caster::INT_5, '10.5', false, 10],
+            [Caster::INT_5, '-10', false, -10],
+            [Caster::INT_5, '-10.5', false, -10],
+            [Caster::INT_5, '-12.5', false, -15],
+            [Caster::INT_5, '-12,5', false, -10],
+            [Caster::INT_5, '-0', false, 0],
+            [Caster::INT_5, 13, false, 15],
+            [Caster::INT_5, 13.7, false, 15],
+            [Caster::INT_5, 12, false, 10],
+            [Caster::INT_5, 12.7, false, 15],
+            [Caster::INT_5, null, false, null],
+            [Caster::INT_5, null, true, 0],
+            [Caster::INT_5, true, false, 0],
+            [Caster::INT_5, false, false, 0],
+            [Caster::FLOAT, 'gibberish', false, 0.0],
+            [Caster::FLOAT, '10', false, 10.0],
+            [Caster::FLOAT, '10.3', false, 10.3],
+            [Caster::FLOAT, '10.5', false, 10.5],
+            [Caster::FLOAT, '10,5', false, 10.0],
+            [Caster::FLOAT, '-10', false, -10.0],
+            [Caster::FLOAT, '-10.5', false, -10.5],
+            [Caster::FLOAT, '-12.5', false, -12.5],
+            [Caster::FLOAT, '-12,5', false, -12.0],
+            [Caster::FLOAT, '-0', false, 0.0],
+            [Caster::FLOAT, 13, false, 13.0],
+            [Caster::FLOAT, 13.7, false, 13.7],
+            [Caster::FLOAT, 12, false, 12.0],
+            [Caster::FLOAT, 12.7, false, 12.7],
+            [Caster::FLOAT, null, false, null],
+            [Caster::FLOAT, null, true, 0.0],
+            [Caster::FLOAT, true, false, 1.0],
+            [Caster::FLOAT, false, false, 0.0],
+            [Caster::BOOL, 10, false, true],
+            [Caster::BOOL, '10', false, true],
+            [Caster::BOOL, 'gibberish', false, true],
+            [Caster::BOOL, null, false, null],
+            [Caster::BOOL, null, true, false],
+            [Caster::BOOL, '', false, false],
+            [Caster::BOOL, true, false, true],
+            [Caster::BOOL, false, false, false],
+            [Caster::ARRAY, 10, false, [10]],
+            [Caster::ARRAY, '10', false, ['10']],
+            [Caster::ARRAY, 'gibberish', false, ['gibberish']],
+            [Caster::ARRAY, null, false, null],
+            [Caster::ARRAY, null, true, []],
+            [Caster::ARRAY, '', false, ['']],
+            [Caster::ARRAY, true, false, [true]],
+            [Caster::ARRAY, false, false, [false]],
+            [Caster::JSON, '{"a":"a"}', false, ['a' => 'a']],
+            [Caster::JSON, '{"a":"a","b":"b","c":{"a":"a"}}', false, ['a' => 'a', 'b' => 'b', 'c' => ['a' => 'a']]],
+            [Caster::JSON, 10, false, 10],
+            [Caster::JSON, 10.3, false, 10.3],
+            [Caster::JSON, '10', false, '10'],
+            [Caster::JSON, null, false, null],
+            [Caster::JSON, null, true, null],
+            [Caster::IDENTIFIER, 10, false, 10],
+            [Caster::IDENTIFIER, 10.3, false, 10.3],
+            [Caster::IDENTIFIER, null, false, null],
+            [Caster::IDENTIFIER, null, true, null],
+            [Caster::IDENTIFIER, [], false, []],
+            [Caster::IDENTIFIER, 'aa', false, 'aa'],
+        ];
+    }
+
+    /**
+     * @dataProvider valueIsCorrectlyCastedProvider
+     */
+    public function test_value_is_correctly_casted(string $dataType, $value, bool $force, $expected)
+    {
+        $caster = Caster::init()->dataType($dataType)->value($value);
+        if ($force) {
+            $caster->force();
+        }
+
+        $this->assertEquals($expected, $caster->getCast());
+    }
+}

--- a/tests/Unit/app/Helpers/NumberFormatterTest.php
+++ b/tests/Unit/app/Helpers/NumberFormatterTest.php
@@ -179,6 +179,7 @@ class NumberFormatterTest extends TestCase
      */
     public function testFormatNumberForUser($number, $isInteger, $alwaysNumber, $expected)
     {
+        // Note: Test currently does not support locale. When we do add a second locale, this will need revisiting.
         $this->assertEquals($expected, NumberFormatter::formatNumberForUser($number, $isInteger, $alwaysNumber));
     }
 }


### PR DESCRIPTION
This PR makes some changes related to the Caster service:
- Updated the Caster to use methods instead of constructor values to set properties.
- Added `force` value to the `reverseFormatted` method to ensure reverse formatting user input doesn't end up as '0' when the user didn't fill in anything.
- Added logic to nullify a user's answer if it was empty (empty string gets cast as '0', which disallowed resetting an answer).
- Added tests for the Caster.