### PR TITLE
Set surface and build year upon registry.

### DIFF
--- a/app/Jobs/CheckBuildingAddress.php
+++ b/app/Jobs/CheckBuildingAddress.php
@@ -36,10 +36,11 @@ class CheckBuildingAddress implements ShouldQueue
     public function handle(BuildingAddressService $buildingAddressService)
     {
         $building = $this->building;
-        $buildingAddressService
-            ->forBuilding($building)
-            ->updateAddress($building->only('postal_code', 'number', 'extension', 'street', 'city'));
+        $buildingAddressService->forBuilding($building);
+        $buildingAddressService->updateAddress($building->only('postal_code', 'number', 'extension', 'street', 'city'));
         $buildingAddressService->attachMunicipality();
+        $buildingAddressService->updateBuildingFeatures($building->only('postal_code', 'number', 'extension'));
+
         /**
          * requery it, no municipality can have multiple causes
          * - BAG is down

--- a/app/Models/BuildingFeature.php
+++ b/app/Models/BuildingFeature.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Traits\GetMyValuesTrait;
 use App\Traits\GetValueTrait;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use OwenIt\Auditing\Contracts\Auditable;
@@ -98,7 +99,8 @@ class BuildingFeature extends Model implements Auditable
 {
     use GetValueTrait,
         GetMyValuesTrait,
-        \App\Traits\Models\Auditable;
+        \App\Traits\Models\Auditable,
+        HasFactory;
 
     protected $fillable = [
         'example_building_id',

--- a/app/Models/InputSource.php
+++ b/app/Models/InputSource.php
@@ -51,4 +51,9 @@ class InputSource extends Model
     {
         return self::findByShort(static::MASTER_SHORT);
     }
+
+    public static function resident(): ?Model
+    {
+        return self::findByShort(static::RESIDENT_SHORT);
+    }
 }

--- a/app/Services/BuildingAddressService.php
+++ b/app/Services/BuildingAddressService.php
@@ -7,14 +7,17 @@ use App\Events\NoMappingFoundForBagMunicipality;
 use App\Events\NoMappingFoundForVbjehuisMunicipality;
 use App\Helpers\MappingHelper;
 use App\Models\Building;
+use App\Models\InputSource;
 use App\Models\Municipality;
+use App\Models\ToolQuestion;
 use App\Services\Lvbag\BagService;
 use App\Traits\FluentCaller;
+use App\Traits\Services\HasInputSources;
 use Illuminate\Support\Arr;
 
 class BuildingAddressService
 {
-    use FluentCaller;
+    use FluentCaller, HasInputSources;
 
     public ?Building $building;
     public BagService $bagService;
@@ -39,7 +42,7 @@ class BuildingAddressService
      * We simply cant rely on external API data, the address data will always be filled with data from the request.
      * We only need it for the IDs.
      *
-     * @param array $fallbackAddressData
+     * @param  array  $fallbackAddressData
      *
      * @return void
      */
@@ -58,7 +61,7 @@ class BuildingAddressService
         $addressData = array_filter($addressData, function ($value, $key) {
             // filter out empty results, only for specific keys
             // we want to clear the bag values.
-            if (! in_array($key, ['bag_addressid', 'bag_woonplaats_id', 'municipality_id'])) {
+            if ( ! in_array($key, ['bag_addressid', 'bag_woonplaats_id', 'municipality_id'])) {
                 return ! empty($value);
             }
             return true;
@@ -73,6 +76,36 @@ class BuildingAddressService
         $this->building->update($buildingData);
     }
 
+    public function updateBuildingFeatures(array $addressData): void
+    {
+        $addressExpanded = $this
+            ->bagService
+            ->addressExpanded(
+                $addressData['postal_code'],
+                $addressData['number'],
+                $addressData['extension']
+            );
+
+        $addressData = $addressExpanded->prepareForBuilding();
+
+        $buildYear = $this->building->getAnswer($this->masterInputSource(), ToolQuestion::findByShort('build-year'));
+        $surface = $this->building->getAnswer($this->masterInputSource(), ToolQuestion::findByShort('surface'));
+
+        $updateableBuildingFeatureData = [];
+        // we only set the data from the bag when its empty, we will never overwrite previous filled in data
+        if (is_null($buildYear)) {
+            $updateableBuildingFeatureData['build_year'] = $addressData['build_year'];
+        }
+        if (is_null($surface)) {
+            $updateableBuildingFeatureData['surface'] = $addressData['surface'];
+        }
+
+        $this->building
+            ->buildingFeatures()
+            ->forInputSource(InputSource::resident())
+            ->update($updateableBuildingFeatureData);
+    }
+
     public function attachMunicipality(): void
     {
         $bagWoonplaatsId = $this->building->bag_woonplaats_id;
@@ -80,7 +113,7 @@ class BuildingAddressService
         $buildingAddressUpdated = false;
 
         $municipalityName = null;
-        if (! empty($bagWoonplaatsId)) {
+        if ( ! empty($bagWoonplaatsId)) {
             // The BAG woonplaats ID cannot be empty. The value passed should be valid (a 4 digit code from BAG), but
             // that should be the only value ever passed, since we save directly from the BAG.
             $municipalityName = optional($this->bagService
@@ -88,7 +121,7 @@ class BuildingAddressService
                 ->municipalityName();
         }
         // It's entirely possible that a municipality is not returned from the bag.
-        if (! is_null($municipalityName)) {
+        if ( ! is_null($municipalityName)) {
             $municipality = $this->mappingService
                 ->from($municipalityName)
                 ->type(MappingHelper::TYPE_BAG_MUNICIPALITY)
@@ -110,7 +143,7 @@ class BuildingAddressService
                     NoMappingFoundForBagMunicipality::dispatch($municipalityName);
                 }
                 // The disassociate only matters when the field was filled before
-                if (! is_null($this->building->municipality_id)) {
+                if ( ! is_null($this->building->municipality_id)) {
                     $buildingAddressUpdated = true;
                 }
                 // remove the relationship.

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -202,6 +202,7 @@ class UserService
             ]
         );
 
+
         $features = new BuildingFeature([
             'surface' => $addressData['surface'] ?? null,
             'build_year' => $addressData['build_year'] ?? null,

--- a/app/Traits/Services/HasInputSources.php
+++ b/app/Traits/Services/HasInputSources.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Traits\Services;
+
+use App\Models\InputSource;
+
+trait HasInputSources
+{
+    public InputSource $inputSource;
+
+    public function forInputSource(InputSource $inputSource): self
+    {
+        $this->inputSource = $inputSource;
+        return $this;
+    }
+
+    public function masterInputSource(): InputSource
+    {
+        return InputSource::master();
+    }
+}

--- a/database/factories/BuildingFeatureFactory.php
+++ b/database/factories/BuildingFeatureFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BuildingFeatureFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
- Upon registry the building feature will get its surface and build year. Implemented it in thhe BuildingAddressService.php and used the method on the CheckBuildingAddress.php job, to keep it consistent throughout the application.

- Also edited the settings controller to make use of the CheckBuildingAddress.php job, now works in similar fashion to the register.