### PR TITLE
Leave out content length

### DIFF
--- a/app/Console/Commands/Api/Econobis/Out/Hoomdossier/PdfReport.php
+++ b/app/Console/Commands/Api/Econobis/Out/Hoomdossier/PdfReport.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\Api\Econobis\Out\Hoomdossier;
 
+use App\Helpers\Queue;
 use App\Jobs\Econobis\Out\SendPdfReportToEconobis;
 use App\Models\FileStorage;
 use App\Models\FileType;
@@ -80,7 +81,7 @@ class PdfReport extends Command
             ->chunkById(50, function ($fileStorages) {
                 foreach ($fileStorages as $fileStorage) {
                     Log::debug("Sending PDF report to Econobis for building {$fileStorage->building_id}");
-                    SendPdfReportToEconobis::dispatch($fileStorage->building);
+                    SendPdfReportToEconobis::dispatch($fileStorage->building)->onQueue(Queue::APP_EXTERNAL);
                 }
             }, FileStorage::getModel()->getTable().'.'.FileStorage::getModel()->getKeyName(), 'file_storage_id');
 

--- a/app/Console/Commands/Api/Econobis/Out/Hoomdossier/PdfReport.php
+++ b/app/Console/Commands/Api/Econobis/Out/Hoomdossier/PdfReport.php
@@ -47,9 +47,6 @@ class PdfReport extends Command
      */
     public function handle()
     {
-        return self::SUCCESS;
-        // disabled for now..
-
         $interval = $this->option('interval');
         $interval = is_numeric($interval) ? (int)$interval : null;
         $interval = is_null($interval) ? config("hoomdossier.services.econobis.interval.".SendPdfReportToEconobis::class) : $interval;

--- a/app/Jobs/Econobis/Out/SendPdfReportToEconobis.php
+++ b/app/Jobs/Econobis/Out/SendPdfReportToEconobis.php
@@ -29,7 +29,6 @@ class SendPdfReportToEconobis implements ShouldQueue
      */
     public function __construct(Building $building)
     {
-        $this->queue = Queue::APP_EXTERNAL;
         $this->building = $building;
     }
 
@@ -42,12 +41,12 @@ class SendPdfReportToEconobis implements ShouldQueue
     {
         Log::debug("Processing PDF report payload to Econobis for building {$this->building->id}");
         Log::debug("Unfortunately PDF report processing has been disabled temporarily.");
-//        $this->wrapCall(function () use ($econobis, $econobisService) {
-//            $econobis
-//                ->forCooperation($this->building->user->cooperation)
-//                ->hoomdossier()
-//                ->pdf($econobisService->forBuilding($this->building)->getPayload(PdfReportPayload::class));
-//        });
+        $this->wrapCall(function () use ($econobis, $econobisService) {
+            $econobis
+                ->forCooperation($this->building->user->cooperation)
+                ->hoomdossier()
+                ->pdf($econobisService->forBuilding($this->building)->getPayload(PdfReportPayload::class));
+        });
     }
 
     /**

--- a/app/Services/Econobis/Api/Client.php
+++ b/app/Services/Econobis/Api/Client.php
@@ -77,7 +77,7 @@ class Client
 
     public function request(string $method, string $uri, array $options = []): array
     {
-        $options = array_merge($options, [RequestOptions::HEADERS => ['Content-Length' => strlen(json_encode($options))]]);
+        //$options = array_merge($options, [RequestOptions::HEADERS => ['Content-Length' => strlen(json_encode($options))]]);
 
         $response = $this->getClient()->request($method, $uri, $options);
 


### PR DESCRIPTION
as it seems it's not always calculated the right way. This would create a false expectation on the receiving end, which might result in a time-out as it the receiver is expecting more bytes to be transferred.