### PR TITLE
Feature/pdf html things

### DIFF
--- a/resources/views/cooperation/pdf/user-report/parts/pages/action-plan.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/action-plan.blade.php
@@ -1,21 +1,21 @@
 @component('cooperation.pdf.user-report.components.new-page', ['id' => 'action-plan'])
     <h1 class="mb-2">
-        @lang('pdf/user-report.pages.action-plan.title')
+        {{ strip_tags(__('pdf/user-report.pages.action-plan.title')) }}
     </h1>
     <p>
-        @lang('pdf/user-report.pages.action-plan.text')
+        {{ strip_tags(__('pdf/user-report.pages.action-plan.text')) }}
     </p>
 
     <div class="group">
         @php $stepShort = $scanShort === \App\Models\Scan::LITE ? 'usage-lite-scan' : 'usage-quick-scan'; @endphp
         <h3>
-            @lang('pdf/user-report.pages.action-plan.usage.current')
+            {{ strip_tags(__('pdf/user-report.pages.action-plan.usage.current')) }}
         </h3>
 
         <div class="row">
             <div class="col-2">
                 <p>
-                    {{ Str::ucfirst(__('general.unit.gas.title')) }}
+                    {{ Str::ucfirst(strip_tags(__('general.unit.gas.title'))) }}
                 </p>
             </div>
             <div class="col-9">
@@ -27,7 +27,7 @@
         <div class="row">
             <div class="col-2">
                 <p>
-                    {{ Str::ucfirst(__('general.unit.electric.title')) }}
+                    {{ Str::ucfirst(strip_tags(__('general.unit.electric.title'))) }}
                 </p>
             </div>
             <div class="col-10">
@@ -40,13 +40,13 @@
 
     <div class="group">
         <h3>
-            @lang('pdf/user-report.pages.action-plan.usage.kengetallen')
+            {{ strip_tags(__('pdf/user-report.pages.action-plan.usage.kengetallen')) }}
         </h3>
 
         <div class="row">
             <div class="col-2">
                 <p>
-                    {{ Str::ucfirst(__('general.unit.gas.title')) }}
+                    {{ Str::ucfirst(strip_tags(__('general.unit.gas.title'))) }}
                 </p>
             </div>
             <div class="col-10">
@@ -58,7 +58,7 @@
         <div class="row">
             <div class="col-2">
                 <p>
-                    {{ Str::ucfirst(__('general.unit.electric.title')) }}
+                    {{ Str::ucfirst(strip_tags(__('general.unit.electric.title'))) }}
                 </p>
             </div>
             <div class="col-10">
@@ -74,24 +74,24 @@
             @php $showDetails = $category !== \App\Services\UserActionPlanAdviceService::CATEGORY_COMPLETE; @endphp
             <div class="group">
                 <h3>
-                    @lang("pdf/user-report.pages.action-plan.categories.{$category}")
+                    {{ strip_tags(__("pdf/user-report.pages.action-plan.categories.{$category}")) }}
                 </h3>
 
                 @if($showDetails)
                     <div class="row">
                         <div class="col-6">
                             <h4>
-                                @lang('pdf/user-report.pages.action-plan.advices.measure')
+                                {{ strip_tags(__('pdf/user-report.pages.action-plan.advices.measure')) }}
                             </h4>
                         </div>
                         <div class="col-3 text-center">
                             <h4>
-                                @lang('pdf/user-report.pages.action-plan.advices.cost-indication')
+                                {{ strip_tags(__('pdf/user-report.pages.action-plan.advices.cost-indication')) }}
                             </h4>
                         </div>
                         <div class="col-3 text-center">
                             <h4>
-                                @lang('pdf/user-report.pages.action-plan.advices.savings')
+                                {{ strip_tags(__('pdf/user-report.pages.action-plan.advices.savings')) }}
                             </h4>
                         </div>
                     </div>
@@ -124,7 +124,7 @@
                     <div class="group">
                         <div class="row">
                             <p>
-                                @lang('pdf/user-report.alerts.text')
+                                {{ strip_tags(__('pdf/user-report.alerts.text')) }}
                             </p>
                         </div>
                     </div>
@@ -136,7 +136,7 @@
     @if($adviceComments->isNotEmpty())
         <div class="group">
             <h4>
-                @lang('pdf/user-report.pages.action-plan.comment')
+                {{ strip_tags(__('pdf/user-report.pages.action-plan.comment')) }}
             </h4>
             @foreach($adviceComments as $comment)
                 <div class="py-2">

--- a/resources/views/cooperation/pdf/user-report/parts/pages/coach-help.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/coach-help.blade.php
@@ -1,6 +1,6 @@
 @component('cooperation.pdf.user-report.components.new-page', ['id' => 'coach-help'])
     <h4>
-        @lang('pdf/user-report.pages.coach-help.title')
+        {{ strip_tags(__('pdf/user-report.pages.coach-help.title')) }}
     </h4>
 
     <div class="group">

--- a/resources/views/cooperation/pdf/user-report/parts/pages/expert-scan-answers.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/expert-scan-answers.blade.php
@@ -8,7 +8,7 @@
 
     <div class="group">
         <h4>
-            @lang('pdf/user-report.pages.expert-scan-answers.action-plan')
+            {{ strip_tags(__('pdf/user-report.pages.expert-scan-answers.action-plan')) }}
         </h4>
         <p>
             @foreach($categorizedAdvices as $category => $advices)

--- a/resources/views/cooperation/pdf/user-report/parts/pages/front-page.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/front-page.blade.php
@@ -75,7 +75,7 @@
     </div>
 
     <h1 class="text-center">
-        @lang('pdf/user-report.pages.front-page.title')
+        {{ strip_tags(__('pdf/user-report.pages.front-page.title')) }}
     </h1>
 
 @endcomponent

--- a/resources/views/cooperation/pdf/user-report/parts/pages/info-page.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/info-page.blade.php
@@ -1,7 +1,7 @@
 @component('cooperation.pdf.user-report.components.new-page', ['id' => 'info-page'])
     <div class="group">
         <h2>
-            @lang('pdf/user-report.pages.info-page.subsidy.title')
+            {{ strip_tags(__('pdf/user-report.pages.info-page.subsidy.title')) }}
         </h2>
         @if(empty($subsidyRegulations))
             <p>

--- a/resources/views/cooperation/pdf/user-report/parts/pages/simple-scan-answers.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/simple-scan-answers.blade.php
@@ -1,6 +1,6 @@
 @component('cooperation.pdf.user-report.components.new-page', ['id' => 'simple-scan-answers'])
     <h1 class="my-2">
-        @lang('pdf/user-report.pages.simple-scan-answers.title')
+        {{ strip_tags(__('pdf/user-report.pages.simple-scan-answers.title')) }}
     </h1>
     <p>
         @lang('pdf/user-report.pages.simple-scan-answers.text')
@@ -21,7 +21,7 @@
 
         <div class="group">
             <h4>
-                @lang('pdf/user-report.alerts.title')
+                {{ strip_tags(__('pdf/user-report.alerts.title')) }}
             </h4>
             @foreach($alerts as $alert)
                 <p class="{{ \App\Services\Models\AlertService::TYPE_MAP[$alert->type] }}">

--- a/resources/views/cooperation/pdf/user-report/parts/pages/small-measures.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/pages/small-measures.blade.php
@@ -1,9 +1,9 @@
 @component('cooperation.pdf.user-report.components.new-page', ['id' => 'small-measures'])
     <h2>
-        @lang('pdf/user-report.pages.small-measures.title')
+        {{ strip_tags(__('pdf/user-report.pages.small-measures.title')) }}
     </h2>
     <p>
-        @lang('pdf/user-report.pages.small-measures.text')
+        {{ strip_tags(__('pdf/user-report.pages.small-measures.text')) }}
     </p>
 
     <div class="group">
@@ -26,7 +26,7 @@
                 <div class="row py-3">
                     <div class="col-3">
                         <h4>
-                            @lang('pdf/user-report.pages.action-plan.advices.cost-indication')
+                            {{ strip_tags(__('pdf/user-report.pages.action-plan.advices.cost-indication')) }}
                         </h4>
                     </div>
                     <div class="col-3">
@@ -36,7 +36,7 @@
                     </div>
                     <div class="col-3">
                         <h4>
-                            @lang('pdf/user-report.pages.action-plan.advices.savings')
+                            {{ strip_tags(__('pdf/user-report.pages.action-plan.advices.savings')) }}
                         </h4>
                     </div>
                     <div class="col-3">

--- a/resources/views/cooperation/pdf/user-report/parts/step-summary.blade.php
+++ b/resources/views/cooperation/pdf/user-report/parts/step-summary.blade.php
@@ -11,7 +11,7 @@
         {{-- Labels get extra styling --}}
         <div class="row">
             <h5>
-                {{ $headers["{$stepShort}.{$key}"] }}
+                {{ strip_tags($headers["{$stepShort}.{$key}"]) }}
             </h5>
         </div>
     @else


### PR DESCRIPTION
Strip tags for given headings in PDF view. The translation manager in the admin might auto-wrap texts in paragraph tags which might break the CSS for the PDF.