### PR TITLE
Per-building scan availability selection

### DIFF
--- a/app/Helpers/Models/BuildingSettingHelper.php
+++ b/app/Helpers/Models/BuildingSettingHelper.php
@@ -9,12 +9,16 @@ class BuildingSettingHelper
 {
     const SHORT_SMALL_MEASURES_ENABLED_QUICK_SCAN = 'small_measures_enabled_quick-scan';
     const SHORT_SMALL_MEASURES_ENABLED_LITE_SCAN = 'small_measures_enabled_lite-scan';
+    const SHORT_SCAN_ENABLED_QUICK_SCAN = 'scan_enabled_quick-scan';
+    const SHORT_SCAN_ENABLED_LITE_SCAN = 'scan_enabled_lite-scan';
 
     public static function getAvailableSettings(): array
     {
         return [
             static::SHORT_SMALL_MEASURES_ENABLED_QUICK_SCAN => 'boolean',
             static::SHORT_SMALL_MEASURES_ENABLED_LITE_SCAN => 'boolean',
+            static::SHORT_SCAN_ENABLED_QUICK_SCAN => 'boolean',
+            static::SHORT_SCAN_ENABLED_LITE_SCAN => 'boolean',
         ];
     }
 

--- a/app/Helpers/ScanAvailabilityHelper.php
+++ b/app/Helpers/ScanAvailabilityHelper.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Helpers\Models\BuildingSettingHelper;
+use App\Models\Building;
+use App\Models\InputSource;
+use App\Models\Scan;
+use App\Models\ToolQuestion;
+use App\Models\ToolQuestionAnswer;
+
+class ScanAvailabilityHelper
+{
+    /**
+     * Check of een scan beschikbaar is voor een building.
+     * Expert scan volgt coöperatieniveau (buiten scope).
+     * null (geen record) = enabled (code-default).
+     */
+    public static function isAvailableForBuilding(Building $building, Scan $scan): bool
+    {
+        // Expert scan: altijd coöperatieniveau, buiten scope
+        if ($scan->isExpertScan()) {
+            return true;
+        }
+
+        // Check of de coöperatie deze scan heeft
+        $cooperation = $building->user->cooperation;
+        if (! $cooperation->scans->contains('id', $scan->id)) {
+            return false;
+        }
+
+        // Check BuildingSetting; null (geen record) = enabled (code-default)
+        $value = BuildingSettingHelper::getSettingValue(
+            $building,
+            static::getBuildingSettingShort($scan),
+            null
+        );
+
+        // null = geen override = enabled (default)
+        if (is_null($value)) {
+            return true;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Heeft het building een antwoord op de roof-type ToolQuestion (eerste unieke quick-scan vraag)?
+     */
+    public static function hasQuickScanData(Building $building): bool
+    {
+        $toolQuestion = ToolQuestion::findByShort('roof-type');
+
+        if (! $toolQuestion) {
+            return false;
+        }
+
+        return ToolQuestionAnswer::forBuilding($building)
+            ->where('tool_question_id', $toolQuestion->id)
+            ->where('input_source_id', InputSource::master()->id)
+            ->exists();
+    }
+
+    /**
+     * Kan de scan ingeschakeld worden? Retourneert true of vertaalsleutel met reden.
+     */
+    public static function canEnable(Building $building, Scan $scan): true|string
+    {
+        // Quick: altijd inschakelen
+        if ($scan->isQuickScan()) {
+            return true;
+        }
+
+        // Lite: alleen als er geen quick-scan data is
+        if ($scan->isLiteScan()) {
+            if (static::hasQuickScanData($building)) {
+                return 'cooperation/admin/buildings.show.scan-availability.disabled-reasons.quick-data-exists';
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Kan de scan uitgeschakeld worden? Retourneert true of vertaalsleutel met reden.
+     * Een scan kan alleen uitgeschakeld worden als de andere scan ook aanstaat.
+     */
+    public static function canDisable(Building $building, Scan $scan): true|string
+    {
+        if ($scan->isLiteScan()) {
+            $quickScan = Scan::quick();
+            if ($quickScan && ! static::isAvailableForBuilding($building, $quickScan)) {
+                return 'cooperation/admin/buildings.show.scan-availability.disabled-reasons.only-active-scan';
+            }
+
+            return true;
+        }
+
+        if ($scan->isQuickScan()) {
+            $liteScan = Scan::lite();
+            if ($liteScan && ! static::isAvailableForBuilding($building, $liteScan)) {
+                return 'cooperation/admin/buildings.show.scan-availability.disabled-reasons.only-active-scan';
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Sla scan beschikbaarheid op.
+     * true/null → scan enabled (verwijder record)
+     * false → '0' opslaan
+     */
+    public static function setAvailability(Building $building, Scan $scan, bool $enabled): void
+    {
+        BuildingSettingHelper::syncSettings($building, [
+            static::getBuildingSettingShort($scan) => $enabled ? null : '0',
+        ]);
+    }
+
+    /**
+     * Get de building setting short voor een specifieke scan.
+     */
+    public static function getBuildingSettingShort(Scan $scan): string
+    {
+        return 'scan_enabled_' . $scan->short;
+    }
+}

--- a/app/Http/Controllers/Cooperation/Admin/BuildingController.php
+++ b/app/Http/Controllers/Cooperation/Admin/BuildingController.php
@@ -20,6 +20,7 @@ use App\Models\PrivateMessage;
 use App\Models\Scan;
 use App\Models\Status;
 use App\Models\User;
+use App\Helpers\ScanAvailabilityHelper;
 use App\Helpers\SmallMeasuresSettingHelper;
 use App\Services\BuildingCoachStatusService;
 use App\Services\UserRoleService;
@@ -77,6 +78,11 @@ class BuildingController extends Controller
             ];
         }
 
+        // Filter scans op building-niveau beschikbaarheid voor de knoppen
+        $availableScans = $scans->filter(
+            fn ($scanItem) => ScanAvailabilityHelper::isAvailableForBuilding($building, $scanItem)
+        );
+
         return view('cooperation.admin.buildings.show', compact(
             'userRoleService',
             'userCurrentRole',
@@ -95,6 +101,7 @@ class BuildingController extends Controller
             'logs',
             'scan',
             'smallMeasuresSettings',
+            'availableScans',
         ));
     }
 

--- a/app/Http/Controllers/Cooperation/Admin/SuperAdmin/Cooperation/UserController.php
+++ b/app/Http/Controllers/Cooperation/Admin/SuperAdmin/Cooperation/UserController.php
@@ -12,6 +12,7 @@ use App\Models\Account;
 use App\Models\Cooperation;
 use App\Models\Role;
 use App\Models\User;
+use App\Services\CooperationScanService;
 use App\Traits\Http\CreatesUsers;
 
 class UserController extends Controller
@@ -49,8 +50,9 @@ class UserController extends Controller
         $userCurrentRole = HoomdossierSession::getRole(true);
         $roles = Role::orderByDesc('level')->get();
         $coaches = $cooperationToManage->getCoaches();
+        $cooperationScanType = CooperationScanService::init($cooperationToManage)->getCurrentType();
 
-        return view('cooperation.admin.users.create', compact('userCurrentRole', 'roles', 'coaches', 'cooperationToManage'));
+        return view('cooperation.admin.users.create', compact('userCurrentRole', 'roles', 'coaches', 'cooperationToManage', 'cooperationScanType'));
     }
 
     public function store(UserFormRequest $request, Cooperation $cooperation, Cooperation $cooperationToManage): RedirectResponse

--- a/app/Http/Controllers/Cooperation/Admin/UserController.php
+++ b/app/Http/Controllers/Cooperation/Admin/UserController.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Cooperation\Admin\Cooperation\UserFormRequest;
 use App\Models\Cooperation;
 use App\Models\User;
+use App\Services\CooperationScanService;
 use App\Services\UserService;
 use App\Traits\Http\CreatesUsers;
 use Illuminate\Http\Request;
@@ -41,8 +42,9 @@ class UserController extends Controller
         $userCurrentRole = HoomdossierSession::getRole(true);
         $roles = Role::orderByDesc('level')->get();
         $coaches = $cooperation->getCoaches();
+        $cooperationScanType = CooperationScanService::init($cooperation)->getCurrentType();
 
-        return view('cooperation.admin.users.create', compact('userCurrentRole', 'roles', 'coaches'));
+        return view('cooperation.admin.users.create', compact('userCurrentRole', 'roles', 'coaches', 'cooperationScanType'));
     }
 
     public function store(UserFormRequest $request, Cooperation $cooperation): RedirectResponse

--- a/app/Http/Controllers/Cooperation/HomeController.php
+++ b/app/Http/Controllers/Cooperation/HomeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Cooperation;
 
 use Illuminate\View\View;
 use App\Helpers\HoomdossierSession;
+use App\Helpers\ScanAvailabilityHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Cooperation;
 use App\Models\Scan;
@@ -15,7 +16,9 @@ class HomeController extends Controller
         $building = HoomdossierSession::getBuilding(true);
         $inputSource = HoomdossierSession::getInputSource(true);
 
-        $scans = $cooperation->load(['scans' => fn($q) => $q->where('short', '!=', Scan::EXPERT)])->scans;
+        $scans = $cooperation->load(['scans' => fn($q) => $q->where('short', '!=', Scan::EXPERT)])->scans
+            ->filter(fn ($scan) => ScanAvailabilityHelper::isAvailableForBuilding($building, $scan))
+            ->values();
 
         return view('cooperation.home.index', compact('building', 'inputSource', 'scans'));
     }

--- a/app/Http/Requests/Cooperation/Admin/Cooperation/UserFormRequest.php
+++ b/app/Http/Requests/Cooperation/Admin/Cooperation/UserFormRequest.php
@@ -39,6 +39,7 @@ class UserFormRequest extends FormRequest
             'users.extra.contact_id' => ['nullable', 'numeric', 'integer', 'gt:0'],
             'roles' => 'required|exists:roles,id', // TODO: This doesn't evaluate if the user may assign the role.
             'coach_id' => ['nullable', Rule::exists('users', 'id')],
+            'scan_variant' => ['nullable', 'in:lite-scan,quick-scan,both-scans'],
         ], (new AddressFormRequest())->setCountry($cooperationToCheckFor->country)->rules());
 
         // try to get the account

--- a/app/Http/ViewComposers/Frontend/Layouts/Parts/SubNavComposer.php
+++ b/app/Http/ViewComposers/Frontend/Layouts/Parts/SubNavComposer.php
@@ -4,6 +4,7 @@ namespace App\Http\ViewComposers\Frontend\Layouts\Parts;
 
 use App\Helpers\Blade\RouteLogic;
 use App\Helpers\HoomdossierSession;
+use App\Helpers\ScanAvailabilityHelper;
 use App\Helpers\SmallMeasuresSettingHelper;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -29,6 +30,11 @@ class SubNavComposer
         $steps = $scan->steps()->with(['questionnaires' => function ($query) use ($cooperation) {
             $query->active()->where('cooperation_id', $cooperation->id)->orderByPivot('order');
         }])->get();
+
+        // Filter scan indien niet beschikbaar voor dit building
+        if ($building && ! ScanAvailabilityHelper::isAvailableForBuilding($building, $scan)) {
+            $steps = collect();
+        }
 
         // Filter kleine maatregelen step indien niet enabled
         if ($building && ! SmallMeasuresSettingHelper::isEnabledForBuilding($building, $scan)) {

--- a/app/Http/ViewComposers/Frontend/Tool/NavbarComposer.php
+++ b/app/Http/ViewComposers/Frontend/Tool/NavbarComposer.php
@@ -3,6 +3,7 @@
 namespace App\Http\ViewComposers\Frontend\Tool;
 
 use App\Helpers\HoomdossierSession;
+use App\Helpers\ScanAvailabilityHelper;
 use App\Helpers\SmallMeasuresSettingHelper;
 use App\Models\InputSource;
 use App\Models\Scan;
@@ -29,6 +30,11 @@ class NavbarComposer
         $scan->load(['steps.subSteps']);
 
         $building = HoomdossierSession::getBuilding(true);
+
+        // Filter scan indien niet beschikbaar voor dit building
+        if ($building && ! ScanAvailabilityHelper::isAvailableForBuilding($building, $scan)) {
+            $scan->setRelation('steps', collect());
+        }
 
         // Filter kleine maatregelen step indien niet enabled
         if ($building && ! SmallMeasuresSettingHelper::isEnabledForBuilding($building, $scan)) {

--- a/app/Livewire/Cooperation/Admin/Buildings/ScanAvailabilityToggle.php
+++ b/app/Livewire/Cooperation/Admin/Buildings/ScanAvailabilityToggle.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Livewire\Cooperation\Admin\Buildings;
+
+use App\Helpers\ScanAvailabilityHelper;
+use App\Models\Building;
+use App\Models\Cooperation;
+use App\Models\Scan;
+use Livewire\Component;
+
+class ScanAvailabilityToggle extends Component
+{
+    public Building $building;
+    public Cooperation $cooperation;
+    public Scan $scan;
+    public bool $enabled = false;
+    public bool $canToggle = true;
+    public string $disabledReason = '';
+
+    public function mount(Building $building, Cooperation $cooperation, Scan $scan): void
+    {
+        $this->building = $building;
+        $this->cooperation = $cooperation;
+        $this->scan = $scan;
+        $this->enabled = ScanAvailabilityHelper::isAvailableForBuilding($building, $scan);
+
+        $this->refreshToggleState();
+    }
+
+    public function updatedEnabled(bool $value): void
+    {
+        if ($value) {
+            $result = ScanAvailabilityHelper::canEnable($this->building, $this->scan);
+            if ($result !== true) {
+                $this->enabled = false;
+                $this->refreshToggleState();
+                return;
+            }
+        } else {
+            $result = ScanAvailabilityHelper::canDisable($this->building, $this->scan);
+            if ($result !== true) {
+                $this->enabled = true;
+                $this->refreshToggleState();
+                return;
+            }
+        }
+
+        ScanAvailabilityHelper::setAvailability($this->building, $this->scan, $value);
+
+        session()->flash('success', __('cooperation/admin/buildings.show.scan-availability.success'));
+
+        $this->js('window.location.reload()');
+    }
+
+    private function refreshToggleState(): void
+    {
+        if ($this->enabled) {
+            $result = ScanAvailabilityHelper::canDisable($this->building, $this->scan);
+            $this->canToggle = $result === true;
+            $this->disabledReason = $result === true ? '' : __($result);
+        } else {
+            $result = ScanAvailabilityHelper::canEnable($this->building, $this->scan);
+            $this->canToggle = $result === true;
+            $this->disabledReason = $result === true ? '' : __($result);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.cooperation.admin.buildings.scan-availability-toggle');
+    }
+}

--- a/app/Policies/SubStepPolicy.php
+++ b/app/Policies/SubStepPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Helpers\Conditions\ConditionEvaluator;
 use App\Helpers\HoomdossierSession;
+use App\Helpers\ScanAvailabilityHelper;
 use App\Helpers\SmallMeasuresSettingHelper;
 use App\Models\Account;
 use App\Models\Building;
@@ -25,8 +26,13 @@ class SubStepPolicy
             $building = HoomdossierSession::getBuilding(true);
         }
 
-        // Check if small-measures step is enabled for this building
+        // Check if scan is available for this building
         $step = $subStep->step;
+        if (! ScanAvailabilityHelper::isAvailableForBuilding($building, $step->scan)) {
+            return false;
+        }
+
+        // Check if small-measures step is enabled for this building
         if ($step->short === 'small-measures') {
             if (! SmallMeasuresSettingHelper::isEnabledForBuilding($building, $step->scan)) {
                 return false;

--- a/app/Traits/Http/CreatesUsers.php
+++ b/app/Traits/Http/CreatesUsers.php
@@ -6,11 +6,13 @@ use App\Events\ParticipantAddedEvent;
 use App\Events\UserAllowedAccessToHisBuilding;
 use App\Events\UserAssociatedWithOtherCooperation;
 use App\Helpers\Hoomdossier;
+use App\Helpers\ScanAvailabilityHelper;
 use App\Helpers\Str;
 use App\Http\Requests\Cooperation\Admin\Cooperation\UserFormRequest;
 use App\Mail\UserCreatedEmail;
 use App\Models\Account;
 use App\Models\Cooperation;
+use App\Models\Scan;
 use App\Models\User;
 use App\Services\BuildingCoachStatusService;
 use App\Services\BuildingPermissionService;
@@ -57,6 +59,20 @@ trait CreatesUsers
 
         // at this point, a user cant register without accepting the privacy terms.
         UserAllowedAccessToHisBuilding::dispatch($user, $building);
+
+        // Set scan availability based on selected variant
+        $scanVariant = $request->input('scan_variant');
+        if ($scanVariant === 'lite-scan') {
+            $quickScan = Scan::quick();
+            if ($quickScan) {
+                ScanAvailabilityHelper::setAvailability($building, $quickScan, false);
+            }
+        } elseif ($scanVariant === 'quick-scan') {
+            $liteScan = Scan::lite();
+            if ($liteScan) {
+                ScanAvailabilityHelper::setAvailability($building, $liteScan, false);
+            }
+        }
 
         // if the created user is a resident, then we connect the selected coach to the building, else we dont.
         if ($request->has('coach_id')) {

--- a/lang/nl/cooperation/admin/buildings.php
+++ b/lang/nl/cooperation/admin/buildings.php
@@ -105,6 +105,17 @@ return [
         'next' => 'Volgende',
         'previous' => 'Vorige',
 
+        'scan-availability' => [
+            'title' => 'Beschikbare scans',
+            'description' => 'Bepaal welke scans beschikbaar zijn voor dit dossier.',
+            'enable-for-building' => 'Beschikbaar',
+            'success' => 'Scan beschikbaarheid bijgewerkt',
+            'disabled-reasons' => [
+                'only-active-scan' => 'Deze scan kan niet worden uitgeschakeld omdat het de enige actieve scan is.',
+                'quick-data-exists' => 'De lite scan kan niet worden ingeschakeld omdat er al data is ingevuld voor de quick scan.',
+            ],
+        ],
+
         'small-measures' => [
             'title' => 'Kleine maatregelen zichtbaarheid',
             'description' => 'De coöperatie heeft kleine maatregelen uitgeschakeld voor de onderstaande scan(s). U kunt deze instelling per woning overschrijven.',

--- a/lang/nl/cooperation/admin/users.php
+++ b/lang/nl/cooperation/admin/users.php
@@ -40,6 +40,9 @@ return [
             'city' => 'Plaats',
             'phone-number' => 'Telefoonnummer',
             'select-coach' => 'Selecteer een coach om te koppelen aan de gebruiker',
+            'scan-variant' => [
+                'label' => 'Welke variant gebruiken?',
+            ],
             'submit' => 'Gebruiker aanmaken',
         ],
     ],

--- a/resources/views/cooperation/admin/buildings/show.blade.php
+++ b/resources/views/cooperation/admin/buildings/show.blade.php
@@ -27,12 +27,12 @@
                 </button>
             @endcan
             @can('access-building', $building)
-                @if($scans->count() > 1)
+                @if($availableScans->count() > 1)
                     @component('cooperation.layouts.components.dropdown', [
                         'label' => __('cooperation/admin/buildings.show.observe-building.label') . '<i class="icon-sm icon-show ml-1"></i>',
                         'class' => 'btn btn-green',
                     ])
-                        @foreach($scans as $scan)
+                        @foreach($availableScans as $scan)
                             @php
                                 $transShort = app(\App\Services\Models\ScanService::class)
                                     ->scan($scan)->forBuilding($building)->hasMadeScanProgress()
@@ -46,7 +46,7 @@
                         @endforeach
                     @endcomponent
                 @else
-                    @foreach($scans as $scan)
+                    @foreach($availableScans as $scan)
                         <a class="btn btn-green" href="{{route('cooperation.admin.tool.observe-tool-for-user', compact('building', 'scan'))}}">
                             <span class="flex items-center">
                                 @lang('cooperation/admin/buildings.show.observe-building.label')
@@ -57,12 +57,12 @@
                 @endif
                 {{-- TODO: This should be a policy --}}
                 @if(Hoomdossier::user()->hasRoleAndIsCurrentRole('coach'))
-                    @if($scans->count() > 1)
+                    @if($availableScans->count() > 1)
                         @component('cooperation.layouts.components.dropdown', [
                             'label' => __('cooperation/admin/buildings.show.fill-for-user.label') . '<i class="icon-sm icon-tools ml-1"></i>',
                             'class' => 'btn btn-yellow',
                         ])
-                            @foreach($scans as $scan)
+                            @foreach($availableScans as $scan)
                                 @php
                                     $transShort = app(\App\Services\Models\ScanService::class)
                                         ->scan($scan)->forBuilding($building)->hasMadeScanProgress()
@@ -76,7 +76,7 @@
                             @endforeach
                         @endcomponent
                     @else
-                        @foreach($scans as $scan)
+                        @foreach($availableScans as $scan)
                             <a class="btn btn-yellow" href="{{route('cooperation.admin.tool.fill-for-user', compact('building', 'scan'))}}">
                                 @php
                                     $transShort = app(\App\Services\Models\ScanService::class)
@@ -199,8 +199,30 @@
         @endcan
     </div>
 
+    {{-- Scan Beschikbaarheid Sectie --}}
+    @if($scans->count() > 1)
+        <div class="w-full mt-6 p-4 border border-gray-200 rounded-lg">
+            <h3 class="text-lg font-semibold mb-4">
+                @lang('cooperation/admin/buildings.show.scan-availability.title')
+            </h3>
+
+            <p class="text-sm text-gray-600 mb-4">
+                @lang('cooperation/admin/buildings.show.scan-availability.description')
+            </p>
+
+            @foreach($scans as $scanItem)
+                <livewire:cooperation.admin.buildings.scan-availability-toggle
+                    :building="$building"
+                    :cooperation="$cooperation"
+                    :scan="$scanItem"
+                    :key="'scan-toggle-' . $scanItem->id"
+                />
+            @endforeach
+        </div>
+    @endif
+
     {{-- Kleine Maatregelen Override Sectie --}}
-    @if(collect($smallMeasuresSettings)->contains('cooperation_enabled', false))
+    @if(collect($smallMeasuresSettings)->contains(fn ($settings, $short) => ! $settings['cooperation_enabled'] && $availableScans->contains('short', $short)))
         <div class="w-full mt-6 p-4 border border-gray-200 rounded-lg">
             <h3 class="text-lg font-semibold mb-4">
                 @lang('cooperation/admin/buildings.show.small-measures.title')
@@ -210,7 +232,7 @@
                 @lang('cooperation/admin/buildings.show.small-measures.description')
             </p>
 
-            @foreach($scans as $scanItem)
+            @foreach($availableScans as $scanItem)
                 @if(! ($smallMeasuresSettings[$scanItem->short]['cooperation_enabled'] ?? true))
                     <livewire:cooperation.admin.buildings.small-measures-toggle
                         :building="$building"

--- a/resources/views/cooperation/admin/users/create.blade.php
+++ b/resources/views/cooperation/admin/users/create.blade.php
@@ -141,6 +141,31 @@
 
             {{-- TODO: Contact ID? --}}
 
+            @if(($cooperationScanType ?? null) === 'both-scans')
+                @component('cooperation.frontend.layouts.components.form-group', [
+                    'class' => 'w-full -mt-5 lg:w-1/2 lg:pr-3',
+                    'label' => __('cooperation/admin/users.create.form.scan-variant.label'),
+                    'id' => 'scan-variant',
+                    'inputName' => 'scan_variant',
+                    'withInputSource' => false,
+                    'attr' => 'x-show="! alreadyMember && ! noBuilding"',
+                ])
+                    @component('cooperation.frontend.layouts.components.alpine-select')
+                        <select id="scan-variant" class="form-input hidden" name="scan_variant">
+                            <option value="both-scans" @if(old('scan_variant', 'both-scans') === 'both-scans') selected @endif>
+                                {{ \App\Services\CooperationScanService::translationMap()['both-scans'] }}
+                            </option>
+                            <option value="lite-scan" @if(old('scan_variant') === 'lite-scan') selected @endif>
+                                {{ \App\Services\CooperationScanService::translationMap()[\App\Models\Scan::LITE] }}
+                            </option>
+                            <option value="quick-scan" @if(old('scan_variant') === 'quick-scan') selected @endif>
+                                {{ \App\Services\CooperationScanService::translationMap()[\App\Models\Scan::QUICK] }}
+                            </option>
+                        </select>
+                    @endcomponent
+                @endcomponent
+            @endif
+
             <h3 class="w-full heading-4 my-4" x-show="! alreadyMember && ! noBuilding">
                 @lang('cooperation/admin/buildings.edit.address-info-title')
             </h3>

--- a/resources/views/livewire/cooperation/admin/buildings/scan-availability-toggle.blade.php
+++ b/resources/views/livewire/cooperation/admin/buildings/scan-availability-toggle.blade.php
@@ -1,0 +1,34 @@
+<div class="flex items-center justify-between mb-3 p-3 bg-gray-50 rounded">
+    <div>
+        <span class="font-medium">{{ $scan->name }}</span>
+    </div>
+
+    <div class="flex items-center">
+        <label class="flex items-center {{ $canToggle ? 'cursor-pointer' : 'cursor-not-allowed opacity-60' }}">
+            <input type="checkbox"
+                   wire:model.live="enabled"
+                   class="h-5 w-5"
+                   @if(! $canToggle) disabled @endif>
+            <span class="ml-2">
+                @lang('cooperation/admin/buildings.show.scan-availability.enable-for-building')
+            </span>
+        </label>
+
+        @if(! $canToggle && $disabledReason)
+            <span class="relative inline-flex items-center ml-2"
+                  x-data="{ show: false }"
+                  x-on:mouseenter="show = true"
+                  x-on:mouseleave="show = false">
+                <i class="icon-sm icon-info-light clickable"></i>
+                <div x-show="show" x-cloak
+                     class="popover popover-left show"
+                     style="right: calc(100% + 0.5rem); top: 50%; transform: translateY(-50%);">
+                    <div class="arrow"></div>
+                    <div class="popover-body">
+                        <p>{{ $disabledReason }}</p>
+                    </div>
+                </div>
+            </span>
+        @endif
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds the ability to enable/disable lite-scan and quick-scan per building (previously only configurable at cooperation level)
- Scan variant dropdown on user creation form (when cooperation has both scans)
- Livewire toggle components on building detail page with restriction logic (can't disable both scans, can't enable lite if quick-scan data exists)
- Filters disabled scans throughout navigation, home page, and SubStepPolicy
- Small measures visibility and coach/admin observe buttons respect per-building scan availability
- Builds on the small measures enabled setting feature (cooperation + building level overrides)