### PR TITLE
Update manual URLs to wiki.econobis.nl

### DIFF
--- a/resources/views/cooperation/admin/layouts/parts/sidebar/manuals-li.blade.php
+++ b/resources/views/cooperation/admin/layouts/parts/sidebar/manuals-li.blade.php
@@ -1,17 +1,17 @@
 @if(in_array(HoomdossierSession::getRole(true)->name, [RoleHelper::ROLE_COOPERATION_ADMIN, RoleHelper::ROLE_COORDINATOR]))
     <li>
-        <a href="https://alfresco.econobis.nl/share/s/hcfoj_gOQByf_moMhrXz2w" target="_blank">
+        <a href="https://wiki.econobis.nl/books/beheerders-en-coachhandleiding/page/beheerdershandleiding" target="_blank">
             Beheerdershandleiding
         </a>
     </li>
 @endif
 <li>
-    <a href="https://alfresco.econobis.nl/share/s/ihlfTvAkSoSgzQTVaJN90A" target="_blank">
+    <a href="https://wiki.econobis.nl/books/beheerders-en-coachhandleiding/page/coachhandleiding-hoomdossier" target="_blank">
         Coachhandleiding
     </a>
 </li>
 <li>
-    <a href="https://alfresco.econobis.nl/share/s/kNtHbpHxTeq5Q5EOib1ySA" target="_blank">
+    <a href="https://wiki.econobis.nl/books/bewonerhandleiding/page/bewonerhandleiding-hoomdossier" target="_blank">
         Bewonershandleiding
     </a>
 </li>


### PR DESCRIPTION
## Summary
- Replace the three Alfresco-hosted manual links in the admin sidebar with their new locations on `wiki.econobis.nl`.
- Affects the sidebar partial `resources/views/cooperation/admin/layouts/parts/sidebar/manuals-li.blade.php`, which is included for cooperation-admin, coordinator and coach roles.

## Changes
- Beheerdershandleiding → `https://wiki.econobis.nl/books/beheerders-en-coachhandleiding/page/beheerdershandleiding`
- Coachhandleiding → `https://wiki.econobis.nl/books/beheerders-en-coachhandleiding/page/coachhandleiding-hoomdossier`
- Bewonershandleiding → `https://wiki.econobis.nl/books/bewonerhandleiding/page/bewonerhandleiding-hoomdossier`

## Test plan
- [x] Log in as cooperation-admin and verify the Beheerdershandleiding link in the sidebar opens the new wiki page in a new tab.
- [x] Log in as coordinator and verify all three links resolve correctly.
- [x] Log in as coach and verify the Coach- and Bewonershandleiding links resolve correctly.