### PR TITLE
Fix null user lookup in ScanAvailabilityHelper for super-admin flow

### DIFF
--- a/app/Helpers/ScanAvailabilityHelper.php
+++ b/app/Helpers/ScanAvailabilityHelper.php
@@ -4,6 +4,7 @@ namespace App\Helpers;
 
 use App\Helpers\Models\BuildingSettingHelper;
 use App\Models\Building;
+use App\Models\Cooperation;
 use App\Models\InputSource;
 use App\Models\Scan;
 use App\Models\ToolQuestion;
@@ -140,7 +141,7 @@ class ScanAvailabilityHelper
     /**
      * Sync scan availability for a building based on a type selection (quick-scan, lite-scan, or both-scans).
      */
-    public static function syncAvailability(Building $building, string $type): void
+    public static function syncAvailability(Building $building, string $type, ?Cooperation $cooperation = null): void
     {
         $enabledScans = [
             Scan::QUICK => [Scan::QUICK],
@@ -149,7 +150,10 @@ class ScanAvailabilityHelper
         ];
 
         $scansToEnable = $enabledScans[$type] ?? [Scan::QUICK];
-        $cooperationScanShorts = $building->user->cooperation->scans->pluck('short')->toArray();
+        // Fall back to the building's owning user/cooperation, bypassing the session's CooperationScope
+        // so super-admin flows targeting another cooperation still resolve correctly.
+        $cooperation ??= $building->user()->withoutGlobalScopes()->first()?->cooperation;
+        $cooperationScanShorts = $cooperation?->scans->pluck('short')->toArray() ?? [];
 
         foreach (Scan::simpleScans()->get() as $scan) {
             $shouldBeEnabled = in_array($scan->short, $scansToEnable);

--- a/app/Livewire/Cooperation/Admin/Buildings/ScanSettings.php
+++ b/app/Livewire/Cooperation/Admin/Buildings/ScanSettings.php
@@ -48,7 +48,7 @@ class ScanSettings extends Component
             return;
         }
 
-        ScanAvailabilityHelper::syncAvailability($this->building, $value);
+        ScanAvailabilityHelper::syncAvailability($this->building, $value, $this->cooperation);
 
         // Clear small measures overrides for scans that are no longer enabled
         $enabledScanShorts = match ($value) {

--- a/app/Traits/Http/CreatesUsers.php
+++ b/app/Traits/Http/CreatesUsers.php
@@ -63,7 +63,7 @@ trait CreatesUsers
 
         // Set scan availability based on selected type
         $scanType = $request->input('scans.type');
-        ScanAvailabilityHelper::syncAvailability($building, $scanType);
+        ScanAvailabilityHelper::syncAvailability($building, $scanType, $cooperation);
 
         // Set small measures overrides, only for scans enabled by the selected type
         $smallMeasuresEnabled = $request->input('scans.small_measures_enabled', []);


### PR DESCRIPTION
## Summary
- Fixes Sentry HOOMDOSSIER-1E1: `Attempt to read property "cooperation" on null` thrown from `ScanAvailabilityHelper::syncAvailability` during super-admin user creation.
- Root cause: the `CooperationScope` global scope on the `User` model filters by the session's active cooperation. When a super-admin creates a user for a different cooperation, `$building->user` returns `null` because the new user's `cooperation_id` doesn't match the session — and `->cooperation` then fails.
- Fix: `syncAvailability()` now accepts an optional `Cooperation` argument; both known callers (`CreatesUsers` and the Livewire `ScanSettings` component) pass the cooperation they already hold. As a defensive fallback, the helper loads the owning user via `withoutGlobalScopes()` so other call sites stay correct in cross-cooperation contexts.

Refs Sentry issue #7476360409.

## Test plan
- [x] Log in as super-admin, add a new cooperation, create a user under it via `/admin/super-admin/cooperations/{slug}/users` — verify no exception and that scan-availability settings are written for the correct cooperation.
- [x] Regular cooperation-admin user creation continues to work and respects scan defaults.
- [x] Livewire `ScanSettings` (admin building scan settings) still toggles scan types correctly.