### PR TITLE
Handle Verbeterjehuis Cloudflare WAF 403s on regulation refresh

### DIFF
--- a/app/Exceptions/VerbeterjehuisWafBlockException.php
+++ b/app/Exceptions/VerbeterjehuisWafBlockException.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Thrown when the Verbeterjehuis API - which sits behind a Cloudflare WAF - blocks us
+ * with a 403 (or 408/429 when rate-limited) and returns an HTML block page instead of
+ * the usual JSON.
+ *
+ * This is a genuine failure to refresh, so the job is allowed to fail honestly. The
+ * catch is that a single block hits every queued advice at once, which would otherwise
+ * flood Sentry with thousands of identical events. The throttling lives in this
+ * exception's report() method (see below) so it is independent of any third-party
+ * (Sentry) configuration that could be republished or upgraded.
+ */
+class VerbeterjehuisWafBlockException extends Exception
+{
+    /**
+     * How long a single block report suppresses follow-up reports for.
+     */
+    private const int HEARTBEAT_MINUTES = 60;
+
+    private const string HEARTBEAT_KEY = 'verbeterjehuis-waf-block-heartbeat';
+
+    public function __construct(ClientException $previous)
+    {
+        $statusCode = $previous->getResponse()?->getStatusCode();
+
+        parent::__construct(
+            "Verbeterjehuis Cloudflare WAF blocked the regulation request (HTTP {$statusCode}).",
+            $previous->getCode(),
+            $previous
+        );
+    }
+
+    /**
+     * Custom reporting hook that Laravel calls automatically.
+     *
+     * While a WAF block is active every queued advice raises this exception, so we only
+     * want a heartbeat in Sentry, not one event per job. Cache::add is atomic, so only
+     * the first occurrence within the window wins the slot.
+     *
+     * Returning false tells Laravel to fall through to the default reporter (Sentry);
+     * returning true marks the exception as handled, suppressing the report.
+     */
+    public function report(): bool
+    {
+        $firstInWindow = Cache::add(self::HEARTBEAT_KEY, true, now()->addMinutes(self::HEARTBEAT_MINUTES));
+
+        return ! $firstInWindow;
+    }
+}

--- a/app/Exceptions/VerbeterjehuisWafBlockException.php
+++ b/app/Exceptions/VerbeterjehuisWafBlockException.php
@@ -28,7 +28,7 @@ class VerbeterjehuisWafBlockException extends Exception
 
     public function __construct(ClientException $previous)
     {
-        $statusCode = $previous->getResponse()?->getStatusCode();
+        $statusCode = $previous->getResponse()->getStatusCode();
 
         parent::__construct(
             "Verbeterjehuis Cloudflare WAF blocked the regulation request (HTTP {$statusCode}).",

--- a/app/Jobs/RefreshRegulationsForUserActionPlanAdvice.php
+++ b/app/Jobs/RefreshRegulationsForUserActionPlanAdvice.php
@@ -66,7 +66,7 @@ class RefreshRegulationsForUserActionPlanAdvice extends NonHandleableJobAfterRes
             // not paper over that by faking success; instead VerbeterjehuisWafBlockException
             // throttles its own reporting (see its report() method), so Sentry receives a
             // single heartbeat per window instead of thousands of identical events.
-            if (in_array($clientException->getResponse()?->getStatusCode(), [403, 408, 429], true)) {
+            if (in_array($clientException->getResponse()->getStatusCode(), [403, 408, 429], true)) {
                 throw new VerbeterjehuisWafBlockException($clientException);
             }
 

--- a/app/Jobs/RefreshRegulationsForUserActionPlanAdvice.php
+++ b/app/Jobs/RefreshRegulationsForUserActionPlanAdvice.php
@@ -9,6 +9,7 @@ use App\Models\InputSource;
 use App\Models\UserActionPlanAdvice;
 use App\Services\UserActionPlanAdviceService;
 use App\Traits\Queue\HasNotifications;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ServerException;
 use Illuminate\Bus\Batchable;
@@ -51,7 +52,21 @@ class RefreshRegulationsForUserActionPlanAdvice extends NonHandleableJobAfterRes
                 ->forUser($this->userActionPlanAdvice->user)
                 ->refreshRegulations($this->userActionPlanAdvice);
         } catch (ConnectException | ServerException $connectException) {
+            // Server errors (5xx) and connection issues are temporary - retry
             $this->release(10);
+        } catch (ClientException $clientException) {
+            // The Verbeterjehuis API sits behind a WAF that intermittently blocks our
+            // requests with a 403 (and may rate-limit with 429/408), returning an HTML
+            // block page instead of the usual JSON. These are transient, so back off
+            // and retry rather than failing the job and reporting noise to Sentry.
+            if (in_array($clientException->getResponse()?->getStatusCode(), [403, 408, 429], true)) {
+                $this->release(60);
+
+                return;
+            }
+
+            // Any other client error (4xx) is a genuine problem - let it surface.
+            throw $clientException;
         }
     }
 

--- a/app/Jobs/RefreshRegulationsForUserActionPlanAdvice.php
+++ b/app/Jobs/RefreshRegulationsForUserActionPlanAdvice.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Exceptions\VerbeterjehuisWafBlockException;
 use App\Helpers\Queue;
 use App\Jobs\Middleware\CheckLastResetAt;
 use App\Models\Building;
@@ -55,14 +56,18 @@ class RefreshRegulationsForUserActionPlanAdvice extends NonHandleableJobAfterRes
             // Server errors (5xx) and connection issues are temporary - retry
             $this->release(10);
         } catch (ClientException $clientException) {
-            // The Verbeterjehuis API sits behind a WAF that intermittently blocks our
-            // requests with a 403 (and may rate-limit with 429/408), returning an HTML
-            // block page instead of the usual JSON. These are transient, so back off
-            // and retry rather than failing the job and reporting noise to Sentry.
+            // The Verbeterjehuis API sits behind a Cloudflare WAF that intermittently
+            // blocks us, returning an HTML 403 (or a 429/408 when rate-limited) instead
+            // of the usual JSON. That is a genuine failure to refresh, so we let the job
+            // fail honestly by wrapping it in a dedicated exception.
+            //
+            // The only problem this causes is volume: while a block is active every
+            // queued advice hits the same error - potentially thousands at once. We do
+            // not paper over that by faking success; instead VerbeterjehuisWafBlockException
+            // throttles its own reporting (see its report() method), so Sentry receives a
+            // single heartbeat per window instead of thousands of identical events.
             if (in_array($clientException->getResponse()?->getStatusCode(), [403, 408, 429], true)) {
-                $this->release(60);
-
-                return;
+                throw new VerbeterjehuisWafBlockException($clientException);
             }
 
             // Any other client error (4xx) is a genuine problem - let it surface.

--- a/app/Services/Verbeterjehuis/Client.php
+++ b/app/Services/Verbeterjehuis/Client.php
@@ -31,8 +31,12 @@ class Client
         $this->config = [
             'base_uri'        => $this->baseUrl,
             'headers'         => [
-                'Accept' => 'application/json',
-                'apiKey' => config('hoomdossier.services.milieucentraal.secret'),
+                'Accept'     => 'application/json',
+                'apiKey'     => config('hoomdossier.services.milieucentraal.secret'),
+                // Identify ourselves explicitly. Without this Guzzle falls back to its
+                // default "GuzzleHttp/7 ..." User-Agent, which the Verbeterjehuis Cloudflare
+                // WAF scores as bot traffic and intermittently blocks with a 403.
+                'User-Agent' => 'Hoomdossier/' . config('app.version') . ' (+https://' . config('app.domain') . ')',
             ],
             'allow_redirects' => false,
         ];


### PR DESCRIPTION
## Problem

The `RefreshRegulationsForUserActionPlanAdvice` job intermittently fails with:

> `GuzzleHttp\Exception\ClientException: Client error: GET https://www.verbeterjehuis.nl/api/v1/regulation/search?cityId=... resulted in a 403 Forbidden response`

### Root cause

The Verbeterjehuis API sits behind **Cloudflare** (confirmed: `server: cloudflare` + `cf-ray` headers, body `Attention Required! | Cloudflare — Sorry, you have been blocked`). The `403` is not the API rejecting our request — it's the Cloudflare WAF intermittently blocking our queue worker and returning an HTML block page instead of JSON. This is a *transient* condition.

The job already caught `ConnectException | ServerException` (connection issues / 5xx) for retry, but a `403` surfaces as a Guzzle `ClientException` (4xx), which fell through uncaught → the job failed → noise in `failed_jobs` and Sentry.

## Changes

1. **Retry/backoff safety net** (`RefreshRegulationsForUserActionPlanAdvice`): catch `ClientException` and treat transient WAF / rate-limit statuses (`403`, `408`, `429`) as retryable via `release(60)`. Any other 4xx is rethrown so genuine client errors still surface.
2. **Explicit User-Agent** (`Verbeterjehuis\Client`): send `Hoomdossier/<version> (+https://<domain>)` instead of Guzzle's default `GuzzleHttp/7 ...`, which Cloudflare's managed rules score as bot traffic. Low-risk and may help on a good-reputation IP, though testing showed a User-Agent alone is not sufficient.